### PR TITLE
Add received handler and writing handler support

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.2.1'
+compile 'io.vertx:vertx-stomp:3.3.0-SNAPSHOT'
 ----
 
 == STOMP server
@@ -721,4 +721,28 @@ var callback = function(frame) {
 client.connect({}, function() {
  var subscription = client.subscribe("foo", callback);
 });
+----
+
+== Registering received and writing frame handlers
+
+STOMP clients, client's connections and server handlers support registering a received
+`link:../dataobjects.html#Frame[Frame]` handler that would be notified every time a frame is received from the wire. It lets
+you log the frames, or implement custom behavior. The handler is already called for `PING`
+frames, and _illegal / unknown_ frames:
+
+[source,groovy]
+----
+Code not translatable
+----
+
+The handler is called before the frame is processed, so you can also _modify_ the frame.
+
+Frames not using a valid STOMP command use the `UNKNOWN` command. The original command is written
+in the headers using the `link:todo[Frame.STOMP_FRAME_COMMAND]` key.
+
+You can also register a handler to be notified when a frame is going to be sent (written to the wire):
+
+[source,groovy]
+----
+Code not translatable
 ----

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.2.1'
+compile 'io.vertx:vertx-stomp:3.3.0-SNAPSHOT'
 ----
 
 == STOMP server
@@ -651,4 +651,37 @@ var callback = function(frame) {
 client.connect({}, function() {
  var subscription = client.subscribe("foo", callback);
 });
+----
+
+== Registering received and writing frame handlers
+
+STOMP clients, client's connections and server handlers support registering a received
+`link:../../apidocs/io/vertx/ext/stomp/Frame.html[Frame]` handler that would be notified every time a frame is received from the wire. It lets
+you log the frames, or implement custom behavior. The handler is already called for `PING`
+frames, and _illegal / unknown_ frames:
+
+[source,java]
+----
+StompServer server = StompServer.create(vertx)
+    .handler(StompServerHandler.create(vertx).receivedFrameHandler(System.out::println))
+    .listen();
+
+StompClient client = StompClient.create(vertx).receivedFrameHandler(System.out::println);
+----
+
+The handler is called before the frame is processed, so you can also _modify_ the frame.
+
+Frames not using a valid STOMP command use the `UNKNOWN` command. The original command is written
+in the headers using the `link:../../apidocs/io/vertx/ext/stomp/Frame.html#STOMP_FRAME_COMMAND[Frame.STOMP_FRAME_COMMAND]` key.
+
+You can also register a handler to be notified when a frame is going to be sent (written to the wire):
+
+[source,java]
+----
+StompServer server = StompServer.create(vertx)
+    .handler(StompServerHandler.create(vertx))
+    .writingFrameHandler(System.out::println)
+    .listen();
+
+StompClient client = StompClient.create(vertx).writingFrameHandler(System.out::println);
 ----

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.2.1'
+compile 'io.vertx:vertx-stomp:3.3.0-SNAPSHOT'
 ----
 
 == STOMP server
@@ -720,4 +720,28 @@ var callback = function(frame) {
 client.connect({}, function() {
  var subscription = client.subscribe("foo", callback);
 });
+----
+
+== Registering received and writing frame handlers
+
+STOMP clients, client's connections and server handlers support registering a received
+`link:../dataobjects.html#Frame[Frame]` handler that would be notified every time a frame is received from the wire. It lets
+you log the frames, or implement custom behavior. The handler is already called for `PING`
+frames, and _illegal / unknown_ frames:
+
+[source,js]
+----
+Code not translatable
+----
+
+The handler is called before the frame is processed, so you can also _modify_ the frame.
+
+Frames not using a valid STOMP command use the `UNKNOWN` command. The original command is written
+in the headers using the `link:todo[Frame.STOMP_FRAME_COMMAND]` key.
+
+You can also register a handler to be notified when a frame is going to be sent (written to the wire):
+
+[source,js]
+----
+Code not translatable
 ----

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.2.1</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.2.1'
+compile 'io.vertx:vertx-stomp:3.3.0-SNAPSHOT'
 ----
 
 == STOMP server
@@ -720,4 +720,28 @@ var callback = function(frame) {
 client.connect({}, function() {
  var subscription = client.subscribe("foo", callback);
 });
+----
+
+== Registering received and writing frame handlers
+
+STOMP clients, client's connections and server handlers support registering a received
+`link:../dataobjects.html#Frame[Frame]` handler that would be notified every time a frame is received from the wire. It lets
+you log the frames, or implement custom behavior. The handler is already called for `PING`
+frames, and _illegal / unknown_ frames:
+
+[source,ruby]
+----
+Code not translatable
+----
+
+The handler is called before the frame is processed, so you can also _modify_ the frame.
+
+Frames not using a valid STOMP command use the `UNKNOWN` command. The original command is written
+in the headers using the `link:todo[Frame.STOMP_FRAME_COMMAND]` key.
+
+You can also register a handler to be notified when a frame is going to be sent (written to the wire):
+
+[source,ruby]
+----
+Code not translatable
 ----

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompClient.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompClient.java
@@ -199,16 +199,30 @@ public class StompClient {
   }
 
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * Configures a received handler that gets notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
    *
    * When a connection is created, the handler is used as
    * {@link io.vertx.ext.stomp.StompClientConnection}.
    * @param handler the handler
    * @return the current {@link io.vertx.ext.stomp.StompClientConnection}
    */
-  public StompClient frameHandler(Handler<Frame> handler) { 
-    this.delegate.frameHandler(handler);
+  public StompClient receivedFrameHandler(Handler<Frame> handler) { 
+    this.delegate.receivedFrameHandler(handler);
+    return this;
+  }
+
+  /**
+   * Configures a writing handler that gets notified when a STOMP frame is written on the wire.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
+   *
+   * When a connection is created, the handler is used as
+   * {@link io.vertx.rxjava.ext.stomp.StompClientConnection#writingFrameHandler}.
+   * @param handler the handler
+   * @return the current {@link io.vertx.rxjava.ext.stomp.StompClientConnection}
+   */
+  public StompClient writingFrameHandler(Handler<Frame> handler) { 
+    this.delegate.writingFrameHandler(handler);
     return this;
   }
 

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompClient.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompClient.java
@@ -19,6 +19,7 @@ package io.vertx.rxjava.ext.stomp;
 import java.util.Map;
 import io.vertx.lang.rxjava.InternalHelper;
 import rx.Observable;
+import io.vertx.ext.stomp.Frame;
 import io.vertx.rxjava.core.Vertx;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -195,6 +196,20 @@ public class StompClient {
     io.vertx.rx.java.ObservableFuture<StompClientConnection> resultHandler = io.vertx.rx.java.RxHelper.observableFuture();
     connect(resultHandler.toHandler());
     return resultHandler;
+  }
+
+  /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   *
+   * When a connection is created, the handler is used as
+   * {@link io.vertx.ext.stomp.StompClientConnection}.
+   * @param handler the handler
+   * @return the current {@link io.vertx.ext.stomp.StompClientConnection}
+   */
+  public StompClient frameHandler(Handler<Frame> handler) { 
+    this.delegate.frameHandler(handler);
+    return this;
   }
 
   /**

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompClientConnection.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompClientConnection.java
@@ -593,6 +593,20 @@ public class StompClientConnection {
     return this;
   }
 
+  /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * <p>
+   * Unlike {@link io.vertx.rxjava.ext.stomp.StompClient#frameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {@link io.vertx.rxjava.ext.stomp.StompClient}, it will be used by all
+   * clients connection, so calling this method is useless, except if you want to use a different handler.
+   * @param handler the handler
+   * @return the current {@link io.vertx.rxjava.ext.stomp.StompClientConnection}
+   */
+  public StompClientConnection frameHandler(Handler<Frame> handler) { 
+    this.delegate.frameHandler(handler);
+    return this;
+  }
+
 
   public static StompClientConnection newInstance(io.vertx.ext.stomp.StompClientConnection arg) {
     return arg != null ? new StompClientConnection(arg) : null;

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompClientConnection.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompClientConnection.java
@@ -594,16 +594,30 @@ public class StompClientConnection {
   }
 
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * Configures a received handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified by the handler.
    * <p>
-   * Unlike {@link io.vertx.rxjava.ext.stomp.StompClient#frameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {@link io.vertx.rxjava.ext.stomp.StompClient}, it will be used by all
+   * Unlike {@link io.vertx.rxjava.ext.stomp.StompClient#receivedFrameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a received frame handler is set on the {@link io.vertx.rxjava.ext.stomp.StompClient}, it will be used by all
    * clients connection, so calling this method is useless, except if you want to use a different handler.
    * @param handler the handler
    * @return the current {@link io.vertx.rxjava.ext.stomp.StompClientConnection}
    */
-  public StompClientConnection frameHandler(Handler<Frame> handler) { 
-    this.delegate.frameHandler(handler);
+  public StompClientConnection receivedFrameHandler(Handler<Frame> handler) { 
+    this.delegate.receivedFrameHandler(handler);
+    return this;
+  }
+
+  /**
+   * Configures a handler notified when a frame is going to be written on the wire. This handler can be used from
+   * logging, debugging. The handler can modify the received frame.
+   *
+   * If a writing frame handler is set on the {@link io.vertx.rxjava.ext.stomp.StompClient}, it will be used by all
+   * clients connection, so calling this method is useless, except if you want to use a different handler.
+   * @param handler the handler
+   * @return the current {@link io.vertx.rxjava.ext.stomp.StompClientConnection}
+   */
+  public StompClientConnection writingFrameHandler(Handler<Frame> handler) { 
+    this.delegate.writingFrameHandler(handler);
     return this;
   }
 

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompServer.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompServer.java
@@ -317,6 +317,21 @@ public class StompServer {
     return ret;
   }
 
+  /**
+   * Configures the handler that is invoked every time a frame is going to be written to the "wire". It lets you log
+   * the frames, but also adapt the frame if needed.
+   * @param handler the handler, must not be <code>null</code>
+   * @return the current {@link io.vertx.ext.stomp.StompServer}
+   */
+  public StompServer writingFrameHandler(Handler<ServerFrame> handler) { 
+    this.delegate.writingFrameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
+      public void handle(io.vertx.ext.stomp.ServerFrame event) {
+        handler.handle(new ServerFrame(event));
+      }
+    });
+    return this;
+  }
+
 
   public static StompServer newInstance(io.vertx.ext.stomp.StompServer arg) {
     return arg != null ? new StompServer(arg) : null;

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompServerHandler.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompServerHandler.java
@@ -64,6 +64,21 @@ public class StompServerHandler implements Handler<ServerFrame> {
   }
 
   /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * @param handler the handler
+   * @return the current {@link io.vertx.rxjava.ext.stomp.StompServerHandler}
+   */
+  public StompServerHandler frameHandler(Handler<ServerFrame> handler) { 
+    this.delegate.frameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
+      public void handle(io.vertx.ext.stomp.ServerFrame event) {
+        handler.handle(new ServerFrame(event));
+      }
+    });
+    return this;
+  }
+
+  /**
    * Configures the action to execute when a <code>CONNECT</code> frame is received.
    * @param handler the handler
    * @return the current {@link io.vertx.rxjava.ext.stomp.StompServerHandler}

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompServerHandler.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompServerHandler.java
@@ -64,13 +64,13 @@ public class StompServerHandler implements Handler<ServerFrame> {
   }
 
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   * Configures a handler that get notified when a STOMP frame is received by the server.
    * This handler can be used for logging, debugging or ad-hoc behavior.
    * @param handler the handler
    * @return the current {@link io.vertx.rxjava.ext.stomp.StompServerHandler}
    */
-  public StompServerHandler frameHandler(Handler<ServerFrame> handler) { 
-    this.delegate.frameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
+  public StompServerHandler receivedFrameHandler(Handler<ServerFrame> handler) { 
+    this.delegate.receivedFrameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
       public void handle(io.vertx.ext.stomp.ServerFrame event) {
         handler.handle(new ServerFrame(event));
       }

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompClient.groovy
@@ -138,16 +138,33 @@ public class StompClient {
     return this;
   }
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * Configures a received handler that gets notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
    *
    * When a connection is created, the handler is used as
-   * {@link io.vertx.groovy.ext.stomp.StompClientConnection#frameHandler}.
+   * {@link io.vertx.groovy.ext.stomp.StompClientConnection#receivedFrameHandler}.
    * @param handler the handler
    * @return the current {@link io.vertx.groovy.ext.stomp.StompClientConnection}
    */
-  public StompClient frameHandler(Handler<Map<String, Object>> handler) {
-    this.delegate.frameHandler(new Handler<Frame>() {
+  public StompClient receivedFrameHandler(Handler<Map<String, Object>> handler) {
+    this.delegate.receivedFrameHandler(new Handler<Frame>() {
+      public void handle(Frame event) {
+        handler.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));
+      }
+    });
+    return this;
+  }
+  /**
+   * Configures a writing handler that gets notified when a STOMP frame is written on the wire.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
+   *
+   * When a connection is created, the handler is used as
+   * {@link io.vertx.groovy.ext.stomp.StompClientConnection#writingFrameHandler}.
+   * @param handler the handler
+   * @return the current {@link io.vertx.groovy.ext.stomp.StompClientConnection}
+   */
+  public StompClient writingFrameHandler(Handler<Map<String, Object>> handler) {
+    this.delegate.writingFrameHandler(new Handler<Frame>() {
       public void handle(Frame event) {
         handler.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));
       }

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompClient.groovy
@@ -18,6 +18,7 @@ package io.vertx.groovy.ext.stomp;
 import groovy.transform.CompileStatic
 import io.vertx.lang.groovy.InternalHelper
 import io.vertx.core.json.JsonObject
+import io.vertx.ext.stomp.Frame
 import io.vertx.groovy.core.Vertx
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
@@ -132,6 +133,23 @@ public class StompClient {
           f = InternalHelper.<StompClientConnection>failure(event.cause())
         }
         resultHandler.handle(f)
+      }
+    });
+    return this;
+  }
+  /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   *
+   * When a connection is created, the handler is used as
+   * {@link io.vertx.groovy.ext.stomp.StompClientConnection#frameHandler}.
+   * @param handler the handler
+   * @return the current {@link io.vertx.groovy.ext.stomp.StompClientConnection}
+   */
+  public StompClient frameHandler(Handler<Map<String, Object>> handler) {
+    this.delegate.frameHandler(new Handler<Frame>() {
+      public void handle(Frame event) {
+        handler.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));
       }
     });
     return this;

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompClientConnection.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompClientConnection.groovy
@@ -636,4 +636,21 @@ public class StompClientConnection {
     });
     return this;
   }
+  /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * <p>
+   * Unlike {@link io.vertx.groovy.ext.stomp.StompClient#frameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {@link io.vertx.groovy.ext.stomp.StompClient}, it will be used by all
+   * clients connection, so calling this method is useless, except if you want to use a different handler.
+   * @param handler the handler
+   * @return the current {@link io.vertx.groovy.ext.stomp.StompClientConnection}
+   */
+  public StompClientConnection frameHandler(Handler<Map<String, Object>> handler) {
+    this.delegate.frameHandler(new Handler<Frame>() {
+      public void handle(Frame event) {
+        handler.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));
+      }
+    });
+    return this;
+  }
 }

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompClientConnection.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompClientConnection.groovy
@@ -637,16 +637,33 @@ public class StompClientConnection {
     return this;
   }
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * Configures a received handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified by the handler.
    * <p>
-   * Unlike {@link io.vertx.groovy.ext.stomp.StompClient#frameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {@link io.vertx.groovy.ext.stomp.StompClient}, it will be used by all
+   * Unlike {@link io.vertx.groovy.ext.stomp.StompClient#receivedFrameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a received frame handler is set on the {@link io.vertx.groovy.ext.stomp.StompClient}, it will be used by all
    * clients connection, so calling this method is useless, except if you want to use a different handler.
    * @param handler the handler
    * @return the current {@link io.vertx.groovy.ext.stomp.StompClientConnection}
    */
-  public StompClientConnection frameHandler(Handler<Map<String, Object>> handler) {
-    this.delegate.frameHandler(new Handler<Frame>() {
+  public StompClientConnection receivedFrameHandler(Handler<Map<String, Object>> handler) {
+    this.delegate.receivedFrameHandler(new Handler<Frame>() {
+      public void handle(Frame event) {
+        handler.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));
+      }
+    });
+    return this;
+  }
+  /**
+   * Configures a handler notified when a frame is going to be written on the wire. This handler can be used from
+   * logging, debugging. The handler can modify the received frame.
+   *
+   * If a writing frame handler is set on the {@link io.vertx.groovy.ext.stomp.StompClient}, it will be used by all
+   * clients connection, so calling this method is useless, except if you want to use a different handler.
+   * @param handler the handler
+   * @return the current {@link io.vertx.groovy.ext.stomp.StompClientConnection}
+   */
+  public StompClientConnection writingFrameHandler(Handler<Map<String, Object>> handler) {
+    this.delegate.writingFrameHandler(new Handler<Frame>() {
       public void handle(Frame event) {
         handler.handle((Map<String, Object>)InternalHelper.wrapObject(event?.toJson()));
       }

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompServer.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompServer.groovy
@@ -245,4 +245,18 @@ public class StompServer {
     };
     return ret;
   }
+  /**
+   * Configures the handler that is invoked every time a frame is going to be written to the "wire". It lets you log
+   * the frames, but also adapt the frame if needed.
+   * @param handler the handler, must not be <code>null</code>
+   * @return the current {@link io.vertx.groovy.ext.stomp.StompServer}
+   */
+  public StompServer writingFrameHandler(Handler<ServerFrame> handler) {
+    this.delegate.writingFrameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
+      public void handle(io.vertx.ext.stomp.ServerFrame event) {
+        handler.handle(new io.vertx.groovy.ext.stomp.ServerFrame(event));
+      }
+    });
+    return this;
+  }
 }

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompServerHandler.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompServerHandler.groovy
@@ -53,13 +53,13 @@ public class StompServerHandler implements Handler<ServerFrame> {
     return ret;
   }
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   * Configures a handler that get notified when a STOMP frame is received by the server.
    * This handler can be used for logging, debugging or ad-hoc behavior.
    * @param handler the handler
    * @return the current {@link io.vertx.groovy.ext.stomp.StompServerHandler}
    */
-  public StompServerHandler frameHandler(Handler<ServerFrame> handler) {
-    this.delegate.frameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
+  public StompServerHandler receivedFrameHandler(Handler<ServerFrame> handler) {
+    this.delegate.receivedFrameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
       public void handle(io.vertx.ext.stomp.ServerFrame event) {
         handler.handle(new io.vertx.groovy.ext.stomp.ServerFrame(event));
       }

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompServerHandler.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompServerHandler.groovy
@@ -53,6 +53,20 @@ public class StompServerHandler implements Handler<ServerFrame> {
     return ret;
   }
   /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * @param handler the handler
+   * @return the current {@link io.vertx.groovy.ext.stomp.StompServerHandler}
+   */
+  public StompServerHandler frameHandler(Handler<ServerFrame> handler) {
+    this.delegate.frameHandler(new Handler<io.vertx.ext.stomp.ServerFrame>() {
+      public void handle(io.vertx.ext.stomp.ServerFrame event) {
+        handler.handle(new io.vertx.groovy.ext.stomp.ServerFrame(event));
+      }
+    });
+    return this;
+  }
+  /**
    * Configures the action to execute when a <code>CONNECT</code> frame is received.
    * @param handler the handler
    * @return the current {@link io.vertx.groovy.ext.stomp.StompServerHandler}

--- a/src/main/java/examples/StompServerExamples.java
+++ b/src/main/java/examples/StompServerExamples.java
@@ -199,4 +199,21 @@ public class StompServerExamples {
         .listen(8080);
   }
 
+  public void example17(Vertx vertx) {
+    StompServer server = StompServer.create(vertx)
+        .handler(StompServerHandler.create(vertx).receivedFrameHandler(System.out::println))
+        .listen();
+
+    StompClient client = StompClient.create(vertx).receivedFrameHandler(System.out::println);
+  }
+
+  public void example18(Vertx vertx) {
+    StompServer server = StompServer.create(vertx)
+        .handler(StompServerHandler.create(vertx))
+        .writingFrameHandler(System.out::println)
+        .listen();
+
+    StompClient client = StompClient.create(vertx).writingFrameHandler(System.out::println);
+  }
+
 }

--- a/src/main/java/io/vertx/ext/stomp/Frame.java
+++ b/src/main/java/io/vertx/ext/stomp/Frame.java
@@ -73,6 +73,12 @@ public class Frame {
   public static final String MESSAGE = "message";
 
   /**
+   * Header used when a frame using an unknown command is received. The created {@link Frame} object uses
+   * the {@link Command#UNKNOWN} command and gives the original command in this header.
+   */
+  public static final String STOMP_FRAME_COMMAND = "frame-command";
+
+  /**
    * Regex used to extract the body encoding that may be specified in the {@code content-type} header. By default,
    * UTF-8 is used.
    */
@@ -106,7 +112,9 @@ public class Frame {
     ERROR,
 
     // This is not a real STOMP frame, it just notice a ping frame from the client.
-    PING
+    PING,
+
+    UNKNOWN
   }
 
   /**
@@ -199,7 +207,7 @@ public class Frame {
    * Only SEND, MESSAGE and ERROR frames accept bodies.
    */
   private final static List<Command> COMMANDS_ACCEPTING_BODY = Arrays.asList(
-      Command.SEND, Command.MESSAGE, Command.ERROR);
+      Command.SEND, Command.MESSAGE, Command.ERROR, Command.UNKNOWN);
 
   private Command command;
 

--- a/src/main/java/io/vertx/ext/stomp/StompClient.java
+++ b/src/main/java/io/vertx/ext/stomp/StompClient.java
@@ -96,6 +96,21 @@ public interface StompClient {
   @Fluent
   StompClient connect(Handler<AsyncResult<StompClientConnection>> resultHandler);
 
+
+
+  /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   *
+   * When a connection is created, the handler is used as
+   * {@link StompClientConnection#frameHandler(Handler)}.
+   *
+   * @param handler the handler
+   * @return the current {@link StompClientConnection}
+   */
+  @Fluent
+  StompClient frameHandler(Handler<Frame> handler);
+
   /**
    * Closes the client.
    */

--- a/src/main/java/io/vertx/ext/stomp/StompClient.java
+++ b/src/main/java/io/vertx/ext/stomp/StompClient.java
@@ -96,20 +96,31 @@ public interface StompClient {
   @Fluent
   StompClient connect(Handler<AsyncResult<StompClientConnection>> resultHandler);
 
-
-
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * Configures a received handler that gets notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
    *
    * When a connection is created, the handler is used as
-   * {@link StompClientConnection#frameHandler(Handler)}.
+   * {@link StompClientConnection#receivedFrameHandler(Handler)}.
    *
    * @param handler the handler
    * @return the current {@link StompClientConnection}
    */
   @Fluent
-  StompClient frameHandler(Handler<Frame> handler);
+  StompClient receivedFrameHandler(Handler<Frame> handler);
+
+  /**
+   * Configures a writing handler that gets notified when a STOMP frame is written on the wire.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
+   *
+   * When a connection is created, the handler is used as
+   * {@link StompClientConnection#writingFrameHandler(Handler)}.
+   *
+   * @param handler the handler
+   * @return the current {@link StompClientConnection}
+   */
+  @Fluent
+  StompClient writingFrameHandler(Handler<Frame> handler);
 
   /**
    * Closes the client.

--- a/src/main/java/io/vertx/ext/stomp/StompClientConnection.java
+++ b/src/main/java/io/vertx/ext/stomp/StompClientConnection.java
@@ -556,4 +556,17 @@ public interface StompClientConnection {
   StompClientConnection nack(String id, String txId, Handler<Frame> receiptHandler);
 
 
+  /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * <p>
+   * Unlike {@link StompClient#frameHandler(Handler)}, the given handler won't receive the {@code
+   * CONNECTED} frame. If a frame handler is set on the {@link StompClient}, it will be used by all
+   * clients connection, so calling this method is useless, except if you want to use a different handler.
+   *
+   * @param handler the handler
+   * @return the current {@link StompClientConnection}
+   */
+  @Fluent
+  StompClientConnection frameHandler(Handler<Frame> handler);
 }

--- a/src/main/java/io/vertx/ext/stomp/StompClientConnection.java
+++ b/src/main/java/io/vertx/ext/stomp/StompClientConnection.java
@@ -256,6 +256,8 @@ public interface StompClientConnection {
   @Fluent
   StompClientConnection closeHandler(Handler<StompClientConnection> handler);
 
+
+
   /**
    * Sets a handler notified when the server does not respond to a {@code ping} request in time. In other
    * words, this handler is invoked when the heartbeat has detected a connection failure with the server.
@@ -557,16 +559,29 @@ public interface StompClientConnection {
 
 
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   * This handler can be used for logging, debugging or ad-hoc behavior.
+   * Configures a received handler that get notified when a STOMP frame is received by the client.
+   * This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified by the handler.
    * <p>
-   * Unlike {@link StompClient#frameHandler(Handler)}, the given handler won't receive the {@code
-   * CONNECTED} frame. If a frame handler is set on the {@link StompClient}, it will be used by all
+   * Unlike {@link StompClient#receivedFrameHandler(Handler)}, the given handler won't receive the {@code
+   * CONNECTED} frame. If a received frame handler is set on the {@link StompClient}, it will be used by all
    * clients connection, so calling this method is useless, except if you want to use a different handler.
    *
    * @param handler the handler
    * @return the current {@link StompClientConnection}
    */
   @Fluent
-  StompClientConnection frameHandler(Handler<Frame> handler);
+  StompClientConnection receivedFrameHandler(Handler<Frame> handler);
+
+  /**
+   * Configures a handler notified when a frame is going to be written on the wire. This handler can be used from
+   * logging, debugging. The handler can modify the received frame.
+   *
+   * If a writing frame handler is set on the {@link StompClient}, it will be used by all
+   * clients connection, so calling this method is useless, except if you want to use a different handler.
+   *
+   * @param handler the handler
+   * @return the current {@link StompClientConnection}
+   */
+  @Fluent
+  StompClientConnection writingFrameHandler(Handler<Frame> handler);
 }

--- a/src/main/java/io/vertx/ext/stomp/StompServer.java
+++ b/src/main/java/io/vertx/ext/stomp/StompServer.java
@@ -200,5 +200,15 @@ public interface StompServer {
    */
   Handler<ServerWebSocket> webSocketHandler();
 
+  /**
+   * Configures the handler that is invoked every time a frame is going to be written to the "wire". It lets you log
+   * the frames, but also adapt the frame if needed.
+   *
+   * @param handler the handler, must not be {@code null}
+   * @return the current {@link StompServer}
+   */
+  @Fluent
+  StompServer writingFrameHandler(Handler<ServerFrame> handler);
+
 
 }

--- a/src/main/java/io/vertx/ext/stomp/StompServerHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/StompServerHandler.java
@@ -48,6 +48,16 @@ public interface StompServerHandler extends Handler<ServerFrame> {
   }
 
   /**
+   * Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   * This handler can be used for logging, debugging or ad-hoc behavior.
+   *
+   * @param handler the handler
+   * @return the current {@link StompServerHandler}
+   */
+  @Fluent
+  StompServerHandler frameHandler(Handler<ServerFrame> handler);
+
+  /**
    * Configures the action to execute when a {@code CONNECT} frame is received.
    *
    * @param handler the handler

--- a/src/main/java/io/vertx/ext/stomp/StompServerHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/StompServerHandler.java
@@ -48,14 +48,14 @@ public interface StompServerHandler extends Handler<ServerFrame> {
   }
 
   /**
-   * Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   * Configures a handler that get notified when a STOMP frame is received by the server.
    * This handler can be used for logging, debugging or ad-hoc behavior.
    *
    * @param handler the handler
    * @return the current {@link StompServerHandler}
    */
   @Fluent
-  StompServerHandler frameHandler(Handler<ServerFrame> handler);
+  StompServerHandler receivedFrameHandler(Handler<ServerFrame> handler);
 
   /**
    * Configures the action to execute when a {@code CONNECT} frame is received.

--- a/src/main/java/io/vertx/ext/stomp/impl/EventBusBridge.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/EventBusBridge.java
@@ -83,12 +83,12 @@ public class EventBusBridge extends Topic {
             Optional<Subscription> chosen = subscriptions.stream().filter(s -> s.destination.equals(address)).findAny();
             if (chosen.isPresent()) {
               Frame stompFrame = transform(msg, chosen.get());
-              chosen.get().connection.write(stompFrame.toBuffer());
+              chosen.get().connection.write(stompFrame);
             }
           } else {
             subscriptions.stream().filter(s -> s.destination.equals(address)).forEach(s -> {
               Frame stompFrame = transform(msg, s);
-              s.connection.write(stompFrame.toBuffer());
+              s.connection.write(stompFrame);
             });
           }
         }));
@@ -227,7 +227,7 @@ public class EventBusBridge extends Topic {
                 .findFirst();
             if (subscription.isPresent()) {
               Frame stompFrame = transform(res.result(), subscription.get());
-              subscription.get().connection.write(stompFrame.toBuffer());
+              subscription.get().connection.write(stompFrame);
             }
           }
         });

--- a/src/main/java/io/vertx/ext/stomp/impl/FrameParser.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/FrameParser.java
@@ -92,7 +92,14 @@ public class FrameParser implements Handler<Buffer> {
         // It's the verb line.
         // We try to find the right verb, here we can trim the line (would remove the optional \r).
         // Commands and Header are encoded in UTF-8 (spec)
-        command = Frame.Command.valueOf(buffer.toString(StompOptions.UTF_8).trim());
+        String commandLine = buffer.toString(StompOptions.UTF_8).trim();
+        try {
+          command = Frame.Command.valueOf(commandLine);
+        } catch (IllegalArgumentException e) {
+          // Not a valid command, use UNKNOWN, and write the given command as header.
+          command = Frame.Command.UNKNOWN;
+          headers.put(Frame.STOMP_FRAME_COMMAND, commandLine);
+        }
         // Only one verb line, so next state
         current = State.HEADERS;
         break;

--- a/src/main/java/io/vertx/ext/stomp/impl/Queue.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/Queue.java
@@ -70,7 +70,7 @@ public class Queue implements Destination {
     Subscription subscription = getNextSubscription();
     String messageId = UUID.randomUUID().toString();
     Frame message = transform(frame, subscription, messageId);
-    subscription.connection.write(message.toBuffer());
+    subscription.connection.write(message);
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/stomp/impl/StompServerImpl.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/StompServerImpl.java
@@ -118,7 +118,7 @@ public class StompServerImpl implements StompServer {
                   }
               )
               .handler(frame -> stomp.handle(new ServerFrameImpl(frame, connection)));
-          socket.handler(parser::handle);
+          socket.handler(parser);
         })
         .listen(port, host, ar -> {
           if (ar.failed()) {

--- a/src/main/java/io/vertx/ext/stomp/impl/StompServerWebSocketConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/StompServerWebSocketConnectionImpl.java
@@ -22,10 +22,7 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
-import io.vertx.ext.stomp.Frame;
-import io.vertx.ext.stomp.StompServer;
-import io.vertx.ext.stomp.StompServerConnection;
-import io.vertx.ext.stomp.StompServerHandler;
+import io.vertx.ext.stomp.*;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -40,8 +37,8 @@ public class StompServerWebSocketConnectionImpl extends  StompServerTCPConnectio
 
   private final ServerWebSocket socket;
 
-  public StompServerWebSocketConnectionImpl(ServerWebSocket socket, StompServer server) {
-    super(server);
+  public StompServerWebSocketConnectionImpl(ServerWebSocket socket, StompServer server, Handler<ServerFrame> writtenFrameHandler) {
+    super(server, writtenFrameHandler);
     Objects.requireNonNull(socket);
     this.socket = socket;
   }

--- a/src/main/java/io/vertx/ext/stomp/impl/Topic.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/Topic.java
@@ -65,7 +65,7 @@ public class Topic implements Destination {
     for (Subscription subscription : subscriptions) {
       String messageId = UUID.randomUUID().toString();
       Frame message = transform(frame, subscription, messageId);
-      subscription.connection.write(message.toBuffer());
+      subscription.connection.write(message);
     }
     return this;
   }

--- a/src/main/java/io/vertx/ext/stomp/package-info.java
+++ b/src/main/java/io/vertx/ext/stomp/package-info.java
@@ -432,6 +432,30 @@
  * });
  * ----
  *
+ * == Registering received and writing frame handlers
+ *
+ * STOMP clients, client's connections and server handlers support registering a received
+ * {@link io.vertx.ext.stomp.Frame} handler that would be notified every time a frame is received from the wire. It lets
+ * you log the frames, or implement custom behavior. The handler is already called for {@code PING}
+ * frames, and _illegal / unknown_ frames:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.StompServerExamples#example17(io.vertx.core.Vertx)}
+ * ----
+ *
+ * The handler is called before the frame is processed, so you can also _modify_ the frame.
+ *
+ * Frames not using a valid STOMP command use the {@code UNKNOWN} command. The original command is written
+ * in the headers using the {@link io.vertx.ext.stomp.Frame#STOMP_FRAME_COMMAND} key.
+ *
+ * You can also register a handler to be notified when a frame is going to be sent (written to the wire):
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.StompServerExamples#example18(io.vertx.core.Vertx)}
+ * ----
+ *
  */
 @ModuleGen(name = "vertx-stomp", groupPackage = "io.vertx")
 @Document(fileName = "index.adoc")

--- a/src/main/resources/vertx-stomp-js/stomp_client.js
+++ b/src/main/resources/vertx-stomp-js/stomp_client.js
@@ -23,6 +23,7 @@ var NetClient = require('vertx-js/net_client');
 var io = Packages.io;
 var JsonObject = io.vertx.core.json.JsonObject;
 var JStompClient = io.vertx.ext.stomp.StompClient;
+var Frame = io.vertx.ext.stomp.Frame;
 var StompClientOptions = io.vertx.ext.stomp.StompClientOptions;
 
 /**
@@ -81,6 +82,27 @@ var StompClient = function(j_val) {
       } else {
         __args[3](null, ar.cause());
       }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   This handler can be used for logging, debugging or ad-hoc behavior.
+  
+   When a connection is created, the handler is used as
+   {@link StompClientConnection#frameHandler}.
+
+   @public
+   @param handler {function} the handler 
+   @return {StompClient} the current {@link StompClientConnection}
+   */
+  this.frameHandler = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_stompClient["frameHandler(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnDataObject(jVal));
     });
       return that;
     } else throw new TypeError('function invoked with invalid arguments');

--- a/src/main/resources/vertx-stomp-js/stomp_client.js
+++ b/src/main/resources/vertx-stomp-js/stomp_client.js
@@ -88,20 +88,41 @@ var StompClient = function(j_val) {
   };
 
   /**
-   Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   This handler can be used for logging, debugging or ad-hoc behavior.
+   Configures a received handler that gets notified when a STOMP frame is received by the client.
+   This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
   
    When a connection is created, the handler is used as
-   {@link StompClientConnection#frameHandler}.
+   {@link StompClientConnection#receivedFrameHandler}.
 
    @public
    @param handler {function} the handler 
    @return {StompClient} the current {@link StompClientConnection}
    */
-  this.frameHandler = function(handler) {
+  this.receivedFrameHandler = function(handler) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
-      j_stompClient["frameHandler(io.vertx.core.Handler)"](function(jVal) {
+      j_stompClient["receivedFrameHandler(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnDataObject(jVal));
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Configures a writing handler that gets notified when a STOMP frame is written on the wire.
+   This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
+  
+   When a connection is created, the handler is used as
+   {@link StompClientConnection#writingFrameHandler}.
+
+   @public
+   @param handler {function} the handler 
+   @return {StompClient} the current {@link StompClientConnection}
+   */
+  this.writingFrameHandler = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_stompClient["writingFrameHandler(io.vertx.core.Handler)"](function(jVal) {
       handler(utils.convReturnDataObject(jVal));
     });
       return that;

--- a/src/main/resources/vertx-stomp-js/stomp_client_connection.js
+++ b/src/main/resources/vertx-stomp-js/stomp_client_connection.js
@@ -453,6 +453,27 @@ var StompClientConnection = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Configures a "general" handler that get notified when a STOMP frame is received by the client.
+   This handler can be used for logging, debugging or ad-hoc behavior.
+   <p>
+   Unlike {@link StompClient#frameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {@link StompClient}, it will be used by all
+   clients connection, so calling this method is useless, except if you want to use a different handler.
+
+   @public
+   @param handler {function} the handler 
+   @return {StompClientConnection} the current {@link StompClientConnection}
+   */
+  this.frameHandler = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_stompClientConnection["frameHandler(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnDataObject(jVal));
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/src/main/resources/vertx-stomp-js/stomp_client_connection.js
+++ b/src/main/resources/vertx-stomp-js/stomp_client_connection.js
@@ -454,20 +454,41 @@ var StompClientConnection = function(j_val) {
   };
 
   /**
-   Configures a "general" handler that get notified when a STOMP frame is received by the client.
-   This handler can be used for logging, debugging or ad-hoc behavior.
+   Configures a received handler that get notified when a STOMP frame is received by the client.
+   This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified by the handler.
    <p>
-   Unlike {@link StompClient#frameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {@link StompClient}, it will be used by all
+   Unlike {@link StompClient#receivedFrameHandler}, the given handler won't receive the <code>CONNECTED</code> frame. If a received frame handler is set on the {@link StompClient}, it will be used by all
    clients connection, so calling this method is useless, except if you want to use a different handler.
 
    @public
    @param handler {function} the handler 
    @return {StompClientConnection} the current {@link StompClientConnection}
    */
-  this.frameHandler = function(handler) {
+  this.receivedFrameHandler = function(handler) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
-      j_stompClientConnection["frameHandler(io.vertx.core.Handler)"](function(jVal) {
+      j_stompClientConnection["receivedFrameHandler(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnDataObject(jVal));
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Configures a handler notified when a frame is going to be written on the wire. This handler can be used from
+   logging, debugging. The handler can modify the received frame.
+  
+   If a writing frame handler is set on the {@link StompClient}, it will be used by all
+   clients connection, so calling this method is useless, except if you want to use a different handler.
+
+   @public
+   @param handler {function} the handler 
+   @return {StompClientConnection} the current {@link StompClientConnection}
+   */
+  this.writingFrameHandler = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_stompClientConnection["writingFrameHandler(io.vertx.core.Handler)"](function(jVal) {
       handler(utils.convReturnDataObject(jVal));
     });
       return that;

--- a/src/main/resources/vertx-stomp-js/stomp_server.js
+++ b/src/main/resources/vertx-stomp-js/stomp_server.js
@@ -20,6 +20,7 @@ var StompServerHandler = require('vertx-stomp-js/stomp_server_handler');
 var ServerWebSocket = require('vertx-js/server_web_socket');
 var NetServer = require('vertx-js/net_server');
 var Vertx = require('vertx-js/vertx');
+var ServerFrame = require('vertx-stomp-js/server_frame');
 
 var io = Packages.io;
 var JsonObject = io.vertx.core.json.JsonObject;
@@ -206,6 +207,24 @@ var StompServer = function(j_val) {
     var __args = arguments;
     if (__args.length === 0) {
       return utils.convReturnHandler(j_stompServer["webSocketHandler()"](), function(result) { return result._jdel; });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+   Configures the handler that is invoked every time a frame is going to be written to the "wire". It lets you log
+   the frames, but also adapt the frame if needed.
+
+   @public
+   @param handler {function} the handler, must not be <code>null</code> 
+   @return {StompServer} the current {@link StompServer}
+   */
+  this.writingFrameHandler = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_stompServer["writingFrameHandler(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(jVal, ServerFrame));
+    });
+      return that;
     } else throw new TypeError('function invoked with invalid arguments');
   };
 

--- a/src/main/resources/vertx-stomp-js/stomp_server_handler.js
+++ b/src/main/resources/vertx-stomp-js/stomp_server_handler.js
@@ -57,17 +57,17 @@ var StompServerHandler = function(j_val) {
   };
 
   /**
-   Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   Configures a handler that get notified when a STOMP frame is received by the server.
    This handler can be used for logging, debugging or ad-hoc behavior.
 
    @public
    @param handler {function} the handler 
    @return {StompServerHandler} the current {@link StompServerHandler}
    */
-  this.frameHandler = function(handler) {
+  this.receivedFrameHandler = function(handler) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'function') {
-      j_stompServerHandler["frameHandler(io.vertx.core.Handler)"](function(jVal) {
+      j_stompServerHandler["receivedFrameHandler(io.vertx.core.Handler)"](function(jVal) {
       handler(utils.convReturnVertxGen(jVal, ServerFrame));
     });
       return that;

--- a/src/main/resources/vertx-stomp-js/stomp_server_handler.js
+++ b/src/main/resources/vertx-stomp-js/stomp_server_handler.js
@@ -57,6 +57,24 @@ var StompServerHandler = function(j_val) {
   };
 
   /**
+   Configures a "general" handler that get notified when a STOMP frame is received by the server.
+   This handler can be used for logging, debugging or ad-hoc behavior.
+
+   @public
+   @param handler {function} the handler 
+   @return {StompServerHandler} the current {@link StompServerHandler}
+   */
+  this.frameHandler = function(handler) {
+    var __args = arguments;
+    if (__args.length === 1 && typeof __args[0] === 'function') {
+      j_stompServerHandler["frameHandler(io.vertx.core.Handler)"](function(jVal) {
+      handler(utils.convReturnVertxGen(jVal, ServerFrame));
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
    Configures the action to execute when a <code>CONNECT</code> frame is received.
 
    @public

--- a/src/main/resources/vertx-stomp/stomp_client.rb
+++ b/src/main/resources/vertx-stomp/stomp_client.rb
@@ -60,19 +60,33 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling connect(param_1,param_2,param_3)"
     end
-    #  Configures a "general" handler that get notified when a STOMP frame is received by the client.
-    #  This handler can be used for logging, debugging or ad-hoc behavior.
+    #  Configures a received handler that gets notified when a STOMP frame is received by the client.
+    #  This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
     # 
     #  When a connection is created, the handler is used as
-    #  {::VertxStomp::StompClientConnection#frame_handler}.
+    #  {::VertxStomp::StompClientConnection#received_frame_handler}.
     # @yield the handler
     # @return [self]
-    def frame_handler
+    def received_frame_handler
       if block_given?
-        @j_del.java_method(:frameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
+        @j_del.java_method(:receivedFrameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
         return self
       end
-      raise ArgumentError, "Invalid arguments when calling frame_handler()"
+      raise ArgumentError, "Invalid arguments when calling received_frame_handler()"
+    end
+    #  Configures a writing handler that gets notified when a STOMP frame is written on the wire.
+    #  This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified at the time.
+    # 
+    #  When a connection is created, the handler is used as
+    #  {::VertxStomp::StompClientConnection#writing_frame_handler}.
+    # @yield the handler
+    # @return [self]
+    def writing_frame_handler
+      if block_given?
+        @j_del.java_method(:writingFrameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling writing_frame_handler()"
     end
     #  Closes the client.
     # @return [void]

--- a/src/main/resources/vertx-stomp/stomp_client.rb
+++ b/src/main/resources/vertx-stomp/stomp_client.rb
@@ -60,6 +60,20 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling connect(param_1,param_2,param_3)"
     end
+    #  Configures a "general" handler that get notified when a STOMP frame is received by the client.
+    #  This handler can be used for logging, debugging or ad-hoc behavior.
+    # 
+    #  When a connection is created, the handler is used as
+    #  {::VertxStomp::StompClientConnection#frame_handler}.
+    # @yield the handler
+    # @return [self]
+    def frame_handler
+      if block_given?
+        @j_del.java_method(:frameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling frame_handler()"
+    end
     #  Closes the client.
     # @return [void]
     def close

--- a/src/main/resources/vertx-stomp/stomp_client_connection.rb
+++ b/src/main/resources/vertx-stomp/stomp_client_connection.rb
@@ -328,5 +328,19 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling nack(id,txId)"
     end
+    #  Configures a "general" handler that get notified when a STOMP frame is received by the client.
+    #  This handler can be used for logging, debugging or ad-hoc behavior.
+    #  <p>
+    #  Unlike {::VertxStomp::StompClient#frame_handler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {::VertxStomp::StompClient}, it will be used by all
+    #  clients connection, so calling this method is useless, except if you want to use a different handler.
+    # @yield the handler
+    # @return [self]
+    def frame_handler
+      if block_given?
+        @j_del.java_method(:frameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling frame_handler()"
+    end
   end
 end

--- a/src/main/resources/vertx-stomp/stomp_client_connection.rb
+++ b/src/main/resources/vertx-stomp/stomp_client_connection.rb
@@ -328,19 +328,33 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling nack(id,txId)"
     end
-    #  Configures a "general" handler that get notified when a STOMP frame is received by the client.
-    #  This handler can be used for logging, debugging or ad-hoc behavior.
+    #  Configures a received handler that get notified when a STOMP frame is received by the client.
+    #  This handler can be used for logging, debugging or ad-hoc behavior. The frame can still be modified by the handler.
     #  <p>
-    #  Unlike {::VertxStomp::StompClient#frame_handler}, the given handler won't receive the <code>CONNECTED</code> frame. If a frame handler is set on the {::VertxStomp::StompClient}, it will be used by all
+    #  Unlike {::VertxStomp::StompClient#received_frame_handler}, the given handler won't receive the <code>CONNECTED</code> frame. If a received frame handler is set on the {::VertxStomp::StompClient}, it will be used by all
     #  clients connection, so calling this method is useless, except if you want to use a different handler.
     # @yield the handler
     # @return [self]
-    def frame_handler
+    def received_frame_handler
       if block_given?
-        @j_del.java_method(:frameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
+        @j_del.java_method(:receivedFrameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
         return self
       end
-      raise ArgumentError, "Invalid arguments when calling frame_handler()"
+      raise ArgumentError, "Invalid arguments when calling received_frame_handler()"
+    end
+    #  Configures a handler notified when a frame is going to be written on the wire. This handler can be used from
+    #  logging, debugging. The handler can modify the received frame.
+    # 
+    #  If a writing frame handler is set on the {::VertxStomp::StompClient}, it will be used by all
+    #  clients connection, so calling this method is useless, except if you want to use a different handler.
+    # @yield the handler
+    # @return [self]
+    def writing_frame_handler
+      if block_given?
+        @j_del.java_method(:writingFrameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(event != nil ? JSON.parse(event.toJson.encode) : nil) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling writing_frame_handler()"
     end
   end
 end

--- a/src/main/resources/vertx-stomp/stomp_server.rb
+++ b/src/main/resources/vertx-stomp/stomp_server.rb
@@ -2,6 +2,7 @@ require 'vertx-stomp/stomp_server_handler'
 require 'vertx/server_web_socket'
 require 'vertx/net_server'
 require 'vertx/vertx'
+require 'vertx-stomp/server_frame'
 require 'vertx/util/utils.rb'
 # Generated from io.vertx.ext.stomp.StompServer
 module VertxStomp
@@ -143,6 +144,17 @@ module VertxStomp
         return ::Vertx::Util::Utils.to_handler_proc(@j_del.java_method(:webSocketHandler, []).call()) { |val| val.j_del }
       end
       raise ArgumentError, "Invalid arguments when calling web_socket_handler()"
+    end
+    #  Configures the handler that is invoked every time a frame is going to be written to the "wire". It lets you log
+    #  the frames, but also adapt the frame if needed.
+    # @yield the handler, must not be <code>null</code>
+    # @return [self]
+    def writing_frame_handler
+      if block_given?
+        @j_del.java_method(:writingFrameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(::Vertx::Util::Utils.safe_create(event,::VertxStomp::ServerFrame)) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling writing_frame_handler()"
     end
   end
 end

--- a/src/main/resources/vertx-stomp/stomp_server_handler.rb
+++ b/src/main/resources/vertx-stomp/stomp_server_handler.rb
@@ -41,6 +41,17 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling create(vertx)"
     end
+    #  Configures a "general" handler that get notified when a STOMP frame is received by the server.
+    #  This handler can be used for logging, debugging or ad-hoc behavior.
+    # @yield the handler
+    # @return [self]
+    def frame_handler
+      if block_given?
+        @j_del.java_method(:frameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(::Vertx::Util::Utils.safe_create(event,::VertxStomp::ServerFrame)) }))
+        return self
+      end
+      raise ArgumentError, "Invalid arguments when calling frame_handler()"
+    end
     #  Configures the action to execute when a <code>CONNECT</code> frame is received.
     # @yield the handler
     # @return [self]

--- a/src/main/resources/vertx-stomp/stomp_server_handler.rb
+++ b/src/main/resources/vertx-stomp/stomp_server_handler.rb
@@ -41,16 +41,16 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling create(vertx)"
     end
-    #  Configures a "general" handler that get notified when a STOMP frame is received by the server.
+    #  Configures a handler that get notified when a STOMP frame is received by the server.
     #  This handler can be used for logging, debugging or ad-hoc behavior.
     # @yield the handler
     # @return [self]
-    def frame_handler
+    def received_frame_handler
       if block_given?
-        @j_del.java_method(:frameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(::Vertx::Util::Utils.safe_create(event,::VertxStomp::ServerFrame)) }))
+        @j_del.java_method(:receivedFrameHandler, [Java::IoVertxCore::Handler.java_class]).call((Proc.new { |event| yield(::Vertx::Util::Utils.safe_create(event,::VertxStomp::ServerFrame)) }))
         return self
       end
-      raise ArgumentError, "Invalid arguments when calling frame_handler()"
+      raise ArgumentError, "Invalid arguments when calling received_frame_handler()"
     end
     #  Configures the action to execute when a <code>CONNECT</code> frame is received.
     # @yield the handler

--- a/src/test/java/io/vertx/ext/stomp/impl/FrameHandlerTest.java
+++ b/src/test/java/io/vertx/ext/stomp/impl/FrameHandlerTest.java
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.stomp.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.NetSocket;
+import io.vertx.ext.stomp.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.StrictAssertions.assertThat;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class FrameHandlerTest {
+
+  private Vertx vertx;
+  private StompServer server;
+  private StompClient client;
+  private Buffer UNKNOWN_FRAME = Buffer.buffer("YEAH\nfoo:val\n\nMy body...")
+      .appendString(FrameParser.NULL);
+
+  // The last connection received by the server.
+  private StompServerConnection connection;
+
+  @Before
+  public void setUp() {
+    AsyncLock<StompServer> lock = new AsyncLock<>();
+    vertx = Vertx.vertx();
+    server = StompServer.create(vertx)
+        .handler(StompServerHandler.create(vertx)
+            .frameHandler(frame -> {
+              receivedByServer.add(frame.frame());
+              connection = frame.connection();
+            }))
+        .listen(lock.handler());
+    lock.waitForSuccess();
+
+    client = StompClient.create(vertx);
+    client.frameHandler(receivedByClient::add);
+  }
+
+  @After
+  public void tearDown() {
+    AsyncLock<Void> lock = new AsyncLock<>();
+    server.close(lock.handler());
+    lock.waitForSuccess();
+    lock = new AsyncLock<>();
+    vertx.close(lock.handler());
+    lock.waitForSuccess();
+    client.close();
+
+    receivedByClient.clear();
+    receivedByServer.clear();
+  }
+
+  List<Frame> receivedByServer = new ArrayList<>();
+  List<Frame> receivedByClient = new ArrayList<>();
+
+  @Test
+  public void testFrameHandler() {
+    AtomicReference<StompClientConnection> reference = new AtomicReference<>();
+    client.connect(connection -> {
+      reference.set(connection.result());
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByServer, Frame.Command.CONNECT));
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByClient, Frame.Command.CONNECTED));
+
+    reference.get().send("foo", Buffer.buffer("hello"), f -> {
+      // just there to receive a reply.
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> containsFrameWithCommand(receivedByServer,
+        Frame.Command.SEND));
+    await().atMost(10, TimeUnit.SECONDS).until(() -> containsFrameWithCommand(receivedByClient,
+        Frame.Command.RECEIPT));
+  }
+
+  @Test
+  public void testFrameHandlerWithPingFrames() {
+    AtomicReference<StompClientConnection> reference = new AtomicReference<>();
+
+    client.connect(connection -> {
+      reference.set(connection.result());
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByServer, Frame.Command.CONNECT));
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByClient, Frame.Command.CONNECTED));
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> containsFrameWithCommand(receivedByServer,
+        Frame.Command.PING));
+    await().atMost(10, TimeUnit.SECONDS).until(() -> containsFrameWithCommand(receivedByClient,
+        Frame.Command.PING));
+  }
+
+  @Test
+  public void testFrameHandlerWithInvalidFramesReceivedByServer() throws InterruptedException {
+    AtomicReference<StompClientConnection> reference = new AtomicReference<>();
+
+    client.connect(connection -> {
+      reference.set(connection.result());
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByServer, Frame.Command.CONNECT));
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByClient, Frame.Command.CONNECTED));
+
+    StompClientConnectionImpl impl = (StompClientConnectionImpl) reference.get();
+    NetSocket socket = impl.socket();
+
+    socket.write(UNKNOWN_FRAME);
+
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByServer, Frame.Command.UNKNOWN));
+
+    Frame frame = getFrameWithCommand(receivedByServer, Frame.Command.UNKNOWN);
+    assertThat(frame).isNotNull();
+    assertThat(frame.getHeader(Frame.STOMP_FRAME_COMMAND)).isEqualToIgnoringCase("YEAH");
+  }
+
+  @Test
+  public void testFrameHandlerWithInvalidFramesReceivedByClient() throws InterruptedException {
+    client.connect(v -> { });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByServer, Frame.Command.CONNECT));
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByClient, Frame.Command.CONNECTED));
+
+    assertThat(connection).isNotNull();
+    connection.write(UNKNOWN_FRAME);
+
+    await().atMost(10, TimeUnit.SECONDS).until(() ->
+        containsFrameWithCommand(receivedByClient, Frame.Command.UNKNOWN));
+    Frame frame = getFrameWithCommand(receivedByClient, Frame.Command.UNKNOWN);
+    assertThat(frame).isNotNull();
+    assertThat(frame.getHeader(Frame.STOMP_FRAME_COMMAND)).isEqualToIgnoringCase("YEAH");
+  }
+
+  private boolean containsFrameWithCommand(List<Frame> frames, Frame.Command command) {
+    for (Frame frame : frames) {
+      if (frame.getCommand() == command) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Frame getFrameWithCommand(List<Frame> frames, Frame.Command command) {
+    for (Frame frame : frames) {
+      if (frame.getCommand() == command) {
+        return frame;
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/test/java/io/vertx/ext/stomp/impl/FrameParserTest.java
+++ b/src/test/java/io/vertx/ext/stomp/impl/FrameParserTest.java
@@ -376,7 +376,7 @@ public class FrameParserTest {
     assertThat(frames.get(1).getBodyAsString()).isEqualTo("Hello World");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testWrongCommand() {
     Buffer buffer = Buffer.buffer("ILLEGAL\n"
         + "accept-version:1.2\n"
@@ -384,7 +384,9 @@ public class FrameParserTest {
         + "\n")
         .appendString(FrameParser.NULL);
 
-    parse(buffer);
+    Frame frame = parse(buffer);
+    assertThat(frame.getCommand()).isEqualTo(Frame.Command.UNKNOWN);
+    assertThat(frame.getHeader(Frame.STOMP_FRAME_COMMAND)).isEqualTo("ILLEGAL");
   }
 
   @Test(expected = FrameException.class)

--- a/src/test/java/io/vertx/ext/stomp/impl/QueueManagingAcknowledgments.java
+++ b/src/test/java/io/vertx/ext/stomp/impl/QueueManagingAcknowledgments.java
@@ -71,7 +71,7 @@ public class QueueManagingAcknowledgments implements Destination {
     String messageId = UUID.randomUUID().toString();
     Frame message = transform(frame, subscription, messageId);
     subscription.enqueue(message);
-    subscription.connection().write(message.toBuffer());
+    subscription.connection().write(message);
     return this;
   }
 
@@ -195,7 +195,7 @@ public class QueueManagingAcknowledgments implements Destination {
           for (Frame f : frames) {
             Frame message = transform(f, next, messageId);
             next.enqueue(message);
-            next.connection().write(message.toBuffer());
+            next.connection().write(message);
           }
         }
         return true;

--- a/src/test/java/io/vertx/ext/stomp/verticles/ReceiverStompClient.java
+++ b/src/test/java/io/vertx/ext/stomp/verticles/ReceiverStompClient.java
@@ -41,11 +41,13 @@ public class ReceiverStompClient extends AbstractVerticle {
         future.fail(ar.cause());
       }
       final StompClientConnection connection = ar.result();
-      connection.frameHandler(frame -> {
-        System.out.println("Client receiving:\n" + frame);
-      }).subscribe("/queue", FRAMES::add, frame -> {
+      connection
+          .receivedFrameHandler(frame -> System.out.println("Client receiving:\n" + frame))
+          .writingFrameHandler(frame -> System.out.println("Client sending:\n" + frame))
+          .subscribe("/queue", FRAMES::add, frame -> {
         future.complete();
       });
     });
+
   }
 }

--- a/src/test/java/io/vertx/ext/stomp/verticles/ReceiverStompClient.java
+++ b/src/test/java/io/vertx/ext/stomp/verticles/ReceiverStompClient.java
@@ -41,7 +41,9 @@ public class ReceiverStompClient extends AbstractVerticle {
         future.fail(ar.cause());
       }
       final StompClientConnection connection = ar.result();
-      connection.subscribe("/queue", FRAMES::add, frame -> {
+      connection.frameHandler(frame -> {
+        System.out.println("Client receiving:\n" + frame);
+      }).subscribe("/queue", FRAMES::add, frame -> {
         future.complete();
       });
     });


### PR DESCRIPTION
Fix #12 

* Add support for unknown frame (unknown command, frame-command header)
* Provide way to register frame handler on the client, server handler and client connection to get frames when they are received
* add support for writingFrameHandler notified when a frame is going to be written on the wire
* Avoid writing buffer directly to allow the interception
* Update documentation and examples