### PR TITLE
Fix #20 - droppedConnectionHandler called twice

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.3.0'
+compile 'io.vertx:vertx-stomp:3.3.1-SNAPSHOT'
 ----
 
 == STOMP server

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -437,7 +437,29 @@ The client can also be notified when a connection drop has been detected. Connec
 STOMP heartbeat mechanism. When the server has not sent a message in the heartbeat time window, the connection is
 closed and the `connectionDroppedHandler` is called (if set). To configure a `connectionDroppedHandler`, call
 `link:../../groovydoc/io/vertx/groovy/ext/stomp/StompClientConnection.html#connectionDroppedHandler(io.vertx.core.Handler)[connectionDroppedHandler]`. The handler can
-for instance tries to reconnect to the server.
+for instance tries to reconnect to the server:
+
+[source,groovy]
+----
+import io.vertx.groovy.core.buffer.Buffer
+import io.vertx.groovy.ext.stomp.StompClient
+def client = StompClient.create(vertx).connect({ ar ->
+  if (ar.succeeded()) {
+    def connection = ar.result()
+    connection.connectionDroppedHandler({ con ->
+      // The connection has been lost
+      // You can reconnect or switch to another server.
+    })
+
+    connection.send("/queue", Buffer.buffer("Hello"), { frame ->
+      println("Message processed by the server")
+    })
+  } else {
+    println("Failed to connect to the STOMP server: ${ar.cause().toString()}")
+  }
+})
+
+----
 
 === Configuration
 
@@ -752,7 +774,17 @@ frames, and _illegal / unknown_ frames:
 
 [source,groovy]
 ----
-Code not translatable
+import io.vertx.groovy.ext.stomp.StompServerHandler
+import io.vertx.groovy.ext.stomp.StompServer
+import io.vertx.groovy.ext.stomp.StompClient
+def server = StompServer.create(vertx).handler(StompServerHandler.create(vertx).receivedFrameHandler({ sf ->
+  println(sf.frame())
+})).listen()
+
+def client = StompClient.create(vertx).receivedFrameHandler({ frame ->
+  println(frame)
+})
+
 ----
 
 The handler is called before the frame is processed, so you can also _modify_ the frame.
@@ -764,5 +796,15 @@ You can also register a handler to be notified when a frame is going to be sent 
 
 [source,groovy]
 ----
-Code not translatable
+import io.vertx.groovy.ext.stomp.StompServerHandler
+import io.vertx.groovy.ext.stomp.StompServer
+import io.vertx.groovy.ext.stomp.StompClient
+def server = StompServer.create(vertx).handler(StompServerHandler.create(vertx)).writingFrameHandler({ sf ->
+  println(sf.frame())
+}).listen()
+
+def client = StompClient.create(vertx).writingFrameHandler({ frame ->
+  println(frame)
+})
+
 ----

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.3.0'
+compile 'io.vertx:vertx-stomp:3.3.1-SNAPSHOT'
 ----
 
 == STOMP server

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -403,7 +403,29 @@ The client can also be notified when a connection drop has been detected. Connec
 STOMP heartbeat mechanism. When the server has not sent a message in the heartbeat time window, the connection is
 closed and the `connectionDroppedHandler` is called (if set). To configure a `connectionDroppedHandler`, call
 `link:../../apidocs/io/vertx/ext/stomp/StompClientConnection.html#connectionDroppedHandler-io.vertx.core.Handler-[connectionDroppedHandler]`. The handler can
-for instance tries to reconnect to the server.
+for instance tries to reconnect to the server:
+
+[source,java]
+----
+StompClient client = StompClient.create(vertx)
+    .connect(ar -> {
+      if (ar.succeeded()) {
+        StompClientConnection connection = ar.result();
+        connection.connectionDroppedHandler(con -> {
+          // The connection has been lost
+          // You can reconnect or switch to another server.
+        });
+
+        connection.send("/queue", Buffer.buffer("Hello"),
+            frame -> {
+              System.out.println("Message processed by the server");
+            }
+        );
+      } else {
+        System.out.println("Failed to connect to the STOMP server: " + ar.cause().toString());
+      }
+    });
+----
 
 === Configuration
 
@@ -683,10 +705,12 @@ frames, and _illegal / unknown_ frames:
 [source,java]
 ----
 StompServer server = StompServer.create(vertx)
-    .handler(StompServerHandler.create(vertx).receivedFrameHandler(System.out::println))
+    .handler(StompServerHandler.create(vertx).receivedFrameHandler(sf -> {
+      System.out.println(sf.frame());
+    }))
     .listen();
 
-StompClient client = StompClient.create(vertx).receivedFrameHandler(System.out::println);
+StompClient client = StompClient.create(vertx).receivedFrameHandler(frame -> System.out.println(frame));
 ----
 
 The handler is called before the frame is processed, so you can also _modify_ the frame.
@@ -700,8 +724,12 @@ You can also register a handler to be notified when a frame is going to be sent 
 ----
 StompServer server = StompServer.create(vertx)
     .handler(StompServerHandler.create(vertx))
-    .writingFrameHandler(System.out::println)
+    .writingFrameHandler(sf -> {
+      System.out.println(sf.frame());
+    })
     .listen();
 
-StompClient client = StompClient.create(vertx).writingFrameHandler(System.out::println);
+StompClient client = StompClient.create(vertx).writingFrameHandler(frame -> {
+  System.out.println(frame);
+});
 ----

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.3.0'
+compile 'io.vertx:vertx-stomp:3.3.1-SNAPSHOT'
 ----
 
 == STOMP server

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -437,7 +437,29 @@ The client can also be notified when a connection drop has been detected. Connec
 STOMP heartbeat mechanism. When the server has not sent a message in the heartbeat time window, the connection is
 closed and the `connectionDroppedHandler` is called (if set). To configure a `connectionDroppedHandler`, call
 `link:../../jsdoc/module-vertx-stomp-js_stomp_client_connection-StompClientConnection.html#connectionDroppedHandler[connectionDroppedHandler]`. The handler can
-for instance tries to reconnect to the server.
+for instance tries to reconnect to the server:
+
+[source,js]
+----
+var Buffer = require("vertx-js/buffer");
+var StompClient = require("vertx-stomp-js/stomp_client");
+var client = StompClient.create(vertx).connect(function (ar, ar_err) {
+  if (ar_err == null) {
+    var connection = ar;
+    connection.connectionDroppedHandler(function (con) {
+      // The connection has been lost
+      // You can reconnect or switch to another server.
+    });
+
+    connection.send("/queue", Buffer.buffer("Hello"), function (frame) {
+      console.log("Message processed by the server");
+    });
+  } else {
+    console.log("Failed to connect to the STOMP server: " + ar_err.toString());
+  }
+});
+
+----
 
 === Configuration
 
@@ -751,7 +773,17 @@ frames, and _illegal / unknown_ frames:
 
 [source,js]
 ----
-Code not translatable
+var StompServerHandler = require("vertx-stomp-js/stomp_server_handler");
+var StompServer = require("vertx-stomp-js/stomp_server");
+var StompClient = require("vertx-stomp-js/stomp_client");
+var server = StompServer.create(vertx).handler(StompServerHandler.create(vertx).receivedFrameHandler(function (sf) {
+  console.log(sf.frame());
+})).listen();
+
+var client = StompClient.create(vertx).receivedFrameHandler(function (frame) {
+  console.log(frame);
+});
+
 ----
 
 The handler is called before the frame is processed, so you can also _modify_ the frame.
@@ -763,5 +795,15 @@ You can also register a handler to be notified when a frame is going to be sent 
 
 [source,js]
 ----
-Code not translatable
+var StompServerHandler = require("vertx-stomp-js/stomp_server_handler");
+var StompServer = require("vertx-stomp-js/stomp_server");
+var StompClient = require("vertx-stomp-js/stomp_client");
+var server = StompServer.create(vertx).handler(StompServerHandler.create(vertx)).writingFrameHandler(function (sf) {
+  console.log(sf.frame());
+}).listen();
+
+var client = StompClient.create(vertx).writingFrameHandler(function (frame) {
+  console.log(frame);
+});
+
 ----

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -24,7 +24,7 @@ descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-stomp</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -32,7 +32,7 @@ descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-stomp:3.3.0'
+compile 'io.vertx:vertx-stomp:3.3.1-SNAPSHOT'
 ----
 
 == STOMP server

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -437,7 +437,29 @@ The client can also be notified when a connection drop has been detected. Connec
 STOMP heartbeat mechanism. When the server has not sent a message in the heartbeat time window, the connection is
 closed and the `connectionDroppedHandler` is called (if set). To configure a `connectionDroppedHandler`, call
 `link:../../yardoc/VertxStomp/StompClientConnection.html#connection_dropped_handler-instance_method[connectionDroppedHandler]`. The handler can
-for instance tries to reconnect to the server.
+for instance tries to reconnect to the server:
+
+[source,ruby]
+----
+require 'vertx/buffer'
+require 'vertx-stomp/stomp_client'
+client = VertxStomp::StompClient.create(vertx).connect() { |ar_err,ar|
+  if (ar_err == nil)
+    connection = ar
+    connection.connection_dropped_handler() { |con|
+      # The connection has been lost
+      # You can reconnect or switch to another server.
+    }
+
+    connection.send("/queue", Vertx::Buffer.buffer("Hello")) { |frame|
+      puts "Message processed by the server"
+    }
+  else
+    puts "Failed to connect to the STOMP server: #{ar_err.to_string()}"
+  end
+}
+
+----
 
 === Configuration
 
@@ -751,7 +773,17 @@ frames, and _illegal / unknown_ frames:
 
 [source,ruby]
 ----
-Code not translatable
+require 'vertx-stomp/stomp_server_handler'
+require 'vertx-stomp/stomp_server'
+require 'vertx-stomp/stomp_client'
+server = VertxStomp::StompServer.create(vertx).handler(VertxStomp::StompServerHandler.create(vertx).received_frame_handler() { |sf|
+  puts sf.frame()
+}).listen()
+
+client = VertxStomp::StompClient.create(vertx).received_frame_handler() { |frame|
+  puts frame
+}
+
 ----
 
 The handler is called before the frame is processed, so you can also _modify_ the frame.
@@ -763,5 +795,15 @@ You can also register a handler to be notified when a frame is going to be sent 
 
 [source,ruby]
 ----
-Code not translatable
+require 'vertx-stomp/stomp_server_handler'
+require 'vertx-stomp/stomp_server'
+require 'vertx-stomp/stomp_client'
+server = VertxStomp::StompServer.create(vertx).handler(VertxStomp::StompServerHandler.create(vertx)).writing_frame_handler() { |sf|
+  puts sf.frame()
+}.listen()
+
+client = VertxStomp::StompClient.create(vertx).writing_frame_handler() { |frame|
+  puts frame
+}
+
 ----

--- a/src/main/generated/io/vertx/rxjava/ext/stomp/StompClient.java
+++ b/src/main/generated/io/vertx/rxjava/ext/stomp/StompClient.java
@@ -254,6 +254,15 @@ public class StompClient {
     return ret;
   }
 
+  /**
+   * @return whether or not the client is connected to the server.
+   * @return 
+   */
+  public boolean isClosed() { 
+    boolean ret = delegate.isClosed();
+    return ret;
+  }
+
 
   public static StompClient newInstance(io.vertx.ext.stomp.StompClient arg) {
     return arg != null ? new StompClient(arg) : null;

--- a/src/main/groovy/io/vertx/groovy/ext/stomp/StompClient.groovy
+++ b/src/main/groovy/io/vertx/groovy/ext/stomp/StompClient.groovy
@@ -200,4 +200,12 @@ public class StompClient {
     def ret = InternalHelper.safeCreate(delegate.vertx(), io.vertx.groovy.core.Vertx.class);
     return ret;
   }
+  /**
+   * @return whether or not the client is connected to the server.
+   * @return 
+   */
+  public boolean isClosed() {
+    def ret = delegate.isClosed();
+    return ret;
+  }
 }

--- a/src/main/java/examples/StompClientExamples.java
+++ b/src/main/java/examples/StompClientExamples.java
@@ -232,5 +232,26 @@ public class StompClientExamples {
         });
   }
 
+  public void example14(Vertx vertx) {
+    StompClient client = StompClient.create(vertx)
+        .connect(ar -> {
+          if (ar.succeeded()) {
+            StompClientConnection connection = ar.result();
+            connection.connectionDroppedHandler(con -> {
+              // The connection has been lost
+              // You can reconnect or switch to another server.
+            });
+
+            connection.send("/queue", Buffer.buffer("Hello"),
+                frame -> {
+                  System.out.println("Message processed by the server");
+                }
+            );
+          } else {
+            System.out.println("Failed to connect to the STOMP server: " + ar.cause().toString());
+          }
+        });
+  }
+
 
 }

--- a/src/main/java/examples/StompServerExamples.java
+++ b/src/main/java/examples/StompServerExamples.java
@@ -201,19 +201,25 @@ public class StompServerExamples {
 
   public void example17(Vertx vertx) {
     StompServer server = StompServer.create(vertx)
-        .handler(StompServerHandler.create(vertx).receivedFrameHandler(System.out::println))
+        .handler(StompServerHandler.create(vertx).receivedFrameHandler(sf -> {
+          System.out.println(sf.frame());
+        }))
         .listen();
 
-    StompClient client = StompClient.create(vertx).receivedFrameHandler(System.out::println);
+    StompClient client = StompClient.create(vertx).receivedFrameHandler(frame -> System.out.println(frame));
   }
 
   public void example18(Vertx vertx) {
     StompServer server = StompServer.create(vertx)
         .handler(StompServerHandler.create(vertx))
-        .writingFrameHandler(System.out::println)
+        .writingFrameHandler(sf -> {
+          System.out.println(sf.frame());
+        })
         .listen();
 
-    StompClient client = StompClient.create(vertx).writingFrameHandler(System.out::println);
+    StompClient client = StompClient.create(vertx).writingFrameHandler(frame -> {
+      System.out.println(frame);
+    });
   }
 
 }

--- a/src/main/java/io/vertx/ext/stomp/StompClient.java
+++ b/src/main/java/io/vertx/ext/stomp/StompClient.java
@@ -147,4 +147,9 @@ public interface StompClient {
    * @return the vert.x instance used by the client.
    */
   Vertx vertx();
+
+  /**
+   * @return whether or not the client is connected to the server.
+   */
+  boolean isClosed();
 }

--- a/src/main/java/io/vertx/ext/stomp/impl/StompClientConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/StompClientConnectionImpl.java
@@ -21,7 +21,10 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
-import io.vertx.ext.stomp.*;
+import io.vertx.ext.stomp.Frame;
+import io.vertx.ext.stomp.Frames;
+import io.vertx.ext.stomp.StompClient;
+import io.vertx.ext.stomp.StompClientConnection;
 import io.vertx.ext.stomp.utils.Headers;
 
 import java.util.*;
@@ -65,6 +68,7 @@ public class StompClientConnectionImpl implements StompClientConnection, Handler
   private Handler<Frame> writingHandler;
 
   private Handler<Frame> errorHandler;
+  private volatile boolean closed;
 
   private static class Subscription {
     final String destination;
@@ -100,8 +104,14 @@ public class StompClientConnectionImpl implements StompClientConnection, Handler
       lastServerActivity = System.nanoTime();
       parser.handle(buffer);
     })
-        .closeHandler(v -> close());
-
+        .closeHandler(v -> {
+          if (!closed) {
+            close();
+            if (droppedHandler != null) {
+              droppedHandler.handle(this);
+            }
+          }
+        });
   }
 
   @Override
@@ -116,6 +126,7 @@ public class StompClientConnectionImpl implements StompClientConnection, Handler
 
   @Override
   public synchronized void close() {
+    closed = true;
 
     if (closeHandler != null) {
       context.runOnContext(v -> closeHandler.handle(this));
@@ -407,7 +418,9 @@ public class StompClientConnectionImpl implements StompClientConnection, Handler
         receiptHandler.handle(f);
       }
       // Close once the receipt have been received.
-      close();
+      if (!closed) {
+        close();
+      }
     });
     return this;
   }
@@ -548,13 +561,14 @@ public class StompClientConnectionImpl implements StompClientConnection, Handler
         if (deltaInMs > pong * 2) {
           LOGGER.error("Disconnecting client " + client + " - no server activity detected in the last " + deltaInMs + " ms.");
           client.vertx().cancelTimer(ponger);
-          disconnect();
 
           // Stack confinement, guarded by the parent class monitor lock.
           Handler<StompClientConnection> handler;
           synchronized (StompClientConnectionImpl.this) {
             handler = droppedHandler;
           }
+
+          disconnect();
 
           if (handler != null) {
             handler.handle(this);

--- a/src/main/java/io/vertx/ext/stomp/package-info.java
+++ b/src/main/java/io/vertx/ext/stomp/package-info.java
@@ -286,7 +286,12 @@
  * STOMP heartbeat mechanism. When the server has not sent a message in the heartbeat time window, the connection is
  * closed and the `connectionDroppedHandler` is called (if set). To configure a `connectionDroppedHandler`, call
  * {@link io.vertx.ext.stomp.StompClientConnection#connectionDroppedHandler(io.vertx.core.Handler)}. The handler can
- * for instance tries to reconnect to the server.
+ * for instance tries to reconnect to the server:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.StompClientExamples#example14(io.vertx.core.Vertx)}
+ * ----
  *
  * === Configuration
  *

--- a/src/main/resources/vertx-stomp-js/stomp_client.js
+++ b/src/main/resources/vertx-stomp-js/stomp_client.js
@@ -189,6 +189,20 @@ var StompClient = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   @return whether or not the client is connected to the server.
+
+   @public
+
+   @return {boolean}
+   */
+  this.isClosed = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      return j_stompClient["isClosed()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/src/main/resources/vertx-stomp/stomp_client.rb
+++ b/src/main/resources/vertx-stomp/stomp_client.rb
@@ -124,5 +124,13 @@ module VertxStomp
       end
       raise ArgumentError, "Invalid arguments when calling vertx()"
     end
+    #  @return whether or not the client is connected to the server.
+    # @return [true,false]
+    def closed?
+      if !block_given?
+        return @j_del.java_method(:isClosed, []).call()
+      end
+      raise ArgumentError, "Invalid arguments when calling closed?()"
+    end
   end
 end

--- a/src/test/java/io/vertx/ext/stomp/impl/StompClientImplTest.java
+++ b/src/test/java/io/vertx/ext/stomp/impl/StompClientImplTest.java
@@ -17,6 +17,8 @@
 package io.vertx.ext.stomp.impl;
 
 import com.jayway.awaitility.Awaitility;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
@@ -27,9 +29,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -335,6 +340,110 @@ public class StompClientImplTest {
     });
 
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(dropped::get);
+  }
+
+
+  @Test
+  public void testReconnection() throws InterruptedException {
+    AtomicBoolean flag = new AtomicBoolean(true);
+    AtomicInteger dropped = new AtomicInteger(0);
+    AtomicInteger connectionCounter = new AtomicInteger();
+    List<ServerFrame> frames = new ArrayList<>();
+    AsyncLock lock = new AsyncLock<>();
+    server.close(lock.handler());
+    lock.waitForSuccess();
+    lock = new AsyncLock();
+    server = StompServer.create(vertx,
+        new StompServerOptions()
+            .setHeartbeat(new JsonObject().put("x", 1000).put("y", 1000)))
+        .handler(StompServerHandler.create(vertx).pingHandler(connection -> {
+          if (flag.get()) {
+            connection.ping();
+          }
+          // When the flag is set to false, the ping are not sent anymore. We use this mechanism to mimic a
+          // server not sending ping anymore.
+        }).receivedFrameHandler(frames::add))
+        .listen(lock.handler());
+    lock.waitForSuccess();
+
+    StompClient client = StompClient.create(vertx, new StompClientOptions().setHeartbeat(new JsonObject()
+        .put("x", 1000).put("y", 1000)));
+    Handler<AsyncResult<StompClientConnection>> connectionHandler = getConnectionHandler(client, flag, dropped,
+        connectionCounter);
+
+    client.connect(connectionHandler);
+
+
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> dropped.get() == 1);
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> connectionCounter.get() == 2);
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> containsClientFrame(frames, 1)
+        &&  containsClientFrame(frames, 2));
+  }
+
+  @Test
+  public void testReconnectionWithDeadServer() throws InterruptedException {
+    AtomicBoolean flag = new AtomicBoolean(true);
+    AtomicInteger dropped = new AtomicInteger(0);
+    AtomicInteger connectionCounter = new AtomicInteger();
+    List<ServerFrame> frames = new ArrayList<>();
+    AsyncLock lock = new AsyncLock<>();
+    server.close(lock.handler());
+    lock.waitForSuccess();
+    lock = new AsyncLock();
+    server = StompServer.create(vertx,
+        new StompServerOptions()
+            .setHeartbeat(new JsonObject().put("x", 1000).put("y", 1000)))
+        .handler(StompServerHandler.create(vertx).pingHandler(connection -> {
+          if (flag.get()) {
+            connection.ping();
+          } else {
+            server.close();
+          }
+          // When the flag is set to false, the ping are not sent anymore. We use this mechanism to mimic a
+          // server not sending ping anymore.
+        }).receivedFrameHandler(frames::add))
+        .listen(lock.handler());
+    lock.waitForSuccess();
+
+    StompClient client = StompClient.create(vertx, new StompClientOptions().setHeartbeat(new JsonObject()
+        .put("x", 1000).put("y", 1000)));
+    Handler<AsyncResult<StompClientConnection>> connectionHandler = getConnectionHandler(client, flag, dropped,
+        connectionCounter);
+
+    client.connect(connectionHandler);
+
+
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> dropped.get() == 1);
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> connectionCounter.get() == 1);
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> containsClientFrame(frames, 1)
+        &&  ! containsClientFrame(frames, 2));
+  }
+
+  private boolean containsClientFrame(List<ServerFrame> frames, int count) {
+    for (ServerFrame frame : frames) {
+      if (frame.frame().getBody() != null  && frame.frame().getBodyAsString().contains("some body " + count)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Handler<AsyncResult<StompClientConnection>> getConnectionHandler(StompClient client, AtomicBoolean flag,
+                                                                           AtomicInteger dropped,
+                                                                           AtomicInteger connection) {
+    return ar -> {
+      if (ar.succeeded()) {
+        ar.result().connectionDroppedHandler(v -> {
+          dropped.incrementAndGet();
+          client.connect(getConnectionHandler(client, flag, dropped, connection));
+        });
+        int count = connection.incrementAndGet();
+        flag.set(false); // Disable the ping.
+        ar.result().send("some-address", Buffer.buffer("some body " + count));
+      } else {
+        // Connection failed.
+      }
+    };
   }
 
 }

--- a/src/test/resources/integration/activemq/Dockerfile
+++ b/src/test/resources/integration/activemq/Dockerfile
@@ -1,10 +1,12 @@
 FROM java:8
 
-RUN curl http://www.mirrorservice.org/sites/ftp.apache.org/activemq/5.13.0/apache-activemq-5.13.0-bin.tar.gz | tar -xz
+ENV VERSION 5.13.3
+
+RUN curl http://www.mirrorservice.org/sites/ftp.apache.org/activemq/$VERSION/apache-activemq-$VERSION-bin.tar.gz | tar -xz
 
 EXPOSE 61612 61613 61616 8161
 
-RUN mv apache-activemq-5.13.0/conf/activemq.xml apache-activemq-5.13.0/conf/activemq.xml.orig
-RUN awk '/.*stomp.*/{print "            <transportConnector name=\"stomp+ssl\" uri=\"stomp+ssl://0.0.0.0:61612\"/>"}1' apache-activemq-5.13.0/conf/activemq.xml.orig >> apache-activemq-5.13.0/conf/activemq.xml
+RUN mv apache-activemq-$VERSION/conf/activemq.xml apache-activemq-$VERSION/conf/activemq.xml.orig
+RUN awk '/.*stomp.*/{print "            <transportConnector name=\"stomp+ssl\" uri=\"stomp+ssl://0.0.0.0:61612\"/>"}1' apache-activemq-$VERSION/conf/activemq.xml.orig >> apache-activemq-$VERSION/conf/activemq.xml
 
-CMD java -Xms1G -Xmx1G -Djava.util.logging.config.file=logging.properties -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote -Djava.io.tmpdir=apache-activemq-5.13.0/tmp -Dactivemq.classpath=apache-activemq-5.13.0/conf -Dactivemq.home=apache-activemq-5.13.0 -Dactivemq.base=apache-activemq-5.13.0 -Dactivemq.conf=apache-activemq-5.13.0/conf -Dactivemq.data=apache-activemq-5.13.0/data -jar apache-activemq-5.13.0/bin/activemq.jar start
+CMD java -Xms1G -Xmx1G -Djava.util.logging.config.file=logging.properties -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote -Djava.io.tmpdir=apache-activemq-$VERSION/tmp -Dactivemq.classpath=apache-activemq-$VERSION/conf -Dactivemq.home=apache-activemq-$VERSION -Dactivemq.base=apache-activemq-$VERSION -Dactivemq.conf=apache-activemq-$VERSION/conf -Dactivemq.data=apache-activemq-$VERSION/data -jar apache-activemq-$VERSION/bin/activemq.jar start

--- a/src/test/resources/integration/artemis/Dockerfile
+++ b/src/test/resources/integration/artemis/Dockerfile
@@ -1,2 +1,2 @@
-FROM vromero/activemq-artemis
+FROM vromero/activemq-artemis:latest
 


### PR DESCRIPTION
Fix issue #20. 

The `droppedConnectionHandler` was called twice making hard to implement reconnection scenarios. In addition it was not called if the connection was closed by the server, while it should still let the user to implement a fail-over behavior in this case.

This PR also fixes 2 code snippet that was not translated in the documentation.