### PR TITLE
#29 Attempt to associate user to session.

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/DefaultConnectHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/DefaultConnectHandler.java
@@ -83,7 +83,7 @@ public class DefaultConnectHandler implements Handler<ServerFrame> {
       String login = frame.getHeader(Frame.LOGIN);
       String passcode = frame.getHeader(Frame.PASSCODE);
 
-      connection.handler().onAuthenticationRequest(connection.server(), login, passcode, ar -> {
+      connection.handler().onAuthenticationRequest(connection, login, passcode, ar -> {
         if (ar.result()) {
           remainingActions.handle(Future.succeededFuture());
         } else {

--- a/src/main/java/io/vertx/ext/stomp/Frame.java
+++ b/src/main/java/io/vertx/ext/stomp/Frame.java
@@ -456,7 +456,7 @@ public class Frame {
   }
 
   /**
-   * This method does not enforce the trainling line option. It should not be used directly, except for the PING frame.
+   * This method does not enforce the trailing line option. It should not be used directly, except for the PING frame.
    *
    * @return a {@link Buffer} containing the STOMP frame. It follows strictly the STOMP specification (including
    * header encoding).

--- a/src/main/java/io/vertx/ext/stomp/StompServerHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/StompServerHandler.java
@@ -22,6 +22,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.stomp.impl.DefaultStompHandler;
 
 import java.util.List;
@@ -177,15 +178,23 @@ public interface StompServerHandler extends Handler<ServerFrame> {
    * Called when the client connects to a server requiring authentication. It invokes the {@link AuthProvider} configured
    * using {@link #authProvider(AuthProvider)}.
    *
-   * @param server   the STOMP server.
-   * @param login    the login
-   * @param passcode the password
-   * @param handler  handler receiving the authentication result
+   * @param connection server connection that contains session ID
+   * @param login      the login
+   * @param passcode   the password
+   * @param handler    handler receiving the authentication result
    * @return the current {@link StompServerHandler}
    */
   @Fluent
-  StompServerHandler onAuthenticationRequest(StompServer server, String login, String passcode,
+  StompServerHandler onAuthenticationRequest(StompServerConnection connection, String login, String passcode,
                                              Handler<AsyncResult<Boolean>> handler);
+
+  /**
+   * Provides for authorization matches on a destination level, this will return the User created by the {@link AuthProvider}.
+   *
+   * @param session session ID for the server connection.
+   * @return null if not authenticated.
+   */
+  User getUserBySession(String session);
 
   /**
    * Configures the {@link AuthProvider} to be used to authenticate the user.

--- a/src/main/java/io/vertx/ext/stomp/impl/DefaultStompHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/DefaultStompHandler.java
@@ -457,18 +457,7 @@ public class DefaultStompHandler implements StompServerHandler {
   public User getUserBySession(String session) {
     return this.users.get(session);
   }
-
-  void accessUserBySession(String session, Handler<User> user) {
-    vertx.sharedData().getLock("user." + session, new Handler<AsyncResult<Lock>>() {
-      @Override
-      public void handle(AsyncResult<Lock> event) {
-        Lock lock = event.result();
-        if (null == lock) {
-          
-        }
-      }
-    });
-  }
+  
   @Override
   public List<Destination> getDestinations() {
     return new ArrayList<>(destinations.keySet());


### PR DESCRIPTION
#29 Basically hold the authenticated user object in the DefaultStompHandler so other handlers or destination factory can access the user per the session. This provides for the possibility of fine grained authorization.