### PR TITLE
Fix issue #43 of StompClient and set default value for acceptedVersions in StompClientOptions(JsonObject json)

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/StompClientOptions.java
+++ b/src/main/java/io/vertx/ext/stomp/StompClientOptions.java
@@ -33,6 +33,8 @@ import java.util.List;
 @DataObject(generateConverter = true)
 public class StompClientOptions extends NetClientOptions implements StompOptions {
 
+  // The default value of reuse address for stomp client
+  private static final boolean DEFAULT_CLIENT_REUSE_ADDRESS = false;
 
   private List<String> acceptedVersions;
   private int port = DEFAULT_STOMP_PORT;
@@ -51,8 +53,9 @@ public class StompClientOptions extends NetClientOptions implements StompOptions
    */
   public StompClientOptions() {
     super();
-    acceptedVersions = new ArrayList<>(DEFAULT_SUPPORTED_VERSIONS);
-    Collections.reverse(acceptedVersions);
+    init();
+    // Override the DEFAULT_REUSE_ADDRESS value in NetworkOptions
+    setReuseAddress(DEFAULT_CLIENT_REUSE_ADDRESS);
   }
 
   /**
@@ -81,7 +84,18 @@ public class StompClientOptions extends NetClientOptions implements StompOptions
    */
   public StompClientOptions(JsonObject json) {
     super(json);
+    init();
     StompClientOptionsConverter.fromJson(json, this);
+
+    // If no valid reuseAddress value specified in the json, set it with DEFAULT_CLIENT_REUSE_ADDRESS
+    if(!(json.getValue("reuseAddress") instanceof Boolean)){
+      setReuseAddress(DEFAULT_CLIENT_REUSE_ADDRESS);
+    }
+  }
+
+  private void init() {
+    acceptedVersions = new ArrayList<>(DEFAULT_SUPPORTED_VERSIONS);
+    Collections.reverse(acceptedVersions);
   }
 
   /**

--- a/src/test/java/io/vertx/ext/stomp/StompClientOptionsTest.java
+++ b/src/test/java/io/vertx/ext/stomp/StompClientOptionsTest.java
@@ -1,0 +1,55 @@
+package io.vertx.ext.stomp;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static io.vertx.ext.stomp.StompOptions.DEFAULT_STOMP_PORT;
+import static io.vertx.ext.stomp.StompOptions.DEFAULT_SUPPORTED_VERSIONS;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Check the behavior of {@link StompClientOptions}.
+ *
+ */
+public class StompClientOptionsTest {
+
+  @Test
+  public void testDefaultConstructor(){
+    StompClientOptions options = new StompClientOptions();
+    assertFalse(options.isReuseAddress());
+    assertEquals(options.getAcceptedVersions().indexOf(DEFAULT_SUPPORTED_VERSIONS.get(0)),
+                  (options.getAcceptedVersions().size()-1));
+    assertEquals( DEFAULT_STOMP_PORT, options.getPort() );
+  }
+
+  @Test
+  public void testReusedAddressInConstructFromJsonObject(){
+    String jsonWithoutReuseAddress = "{\"host\": \"127.0.0.1\"}";
+    StompClientOptions options0  = new StompClientOptions(new JsonObject(jsonWithoutReuseAddress));
+    assertFalse(options0.isReuseAddress());
+
+    String jsonWithValidReuseAddress = "{\"reuseAddress\": true}";
+    StompClientOptions options1  = new StompClientOptions(new JsonObject(jsonWithValidReuseAddress));
+    assertTrue(options1.isReuseAddress());
+
+    String jsonWithInvalidReuseAddress = "{\"reuseAddress\": \"none\"}";
+    StompClientOptions options2  = new StompClientOptions(new JsonObject(jsonWithInvalidReuseAddress));
+    assertFalse(options2.isReuseAddress() );
+  }
+
+  @Test
+  public void testAcceptedVersionsInConstructFromJsonObject(){
+    String jsonWithoutAcceptedVersions = "{\"host\": \"127.0.0.1\"}";
+    StompClientOptions options0  = new StompClientOptions(new JsonObject(jsonWithoutAcceptedVersions));
+    assertEquals(options0.getAcceptedVersions().
+      indexOf(DEFAULT_SUPPORTED_VERSIONS.get(0)), (options0.getAcceptedVersions().size()-1));
+
+    String jsonWithValidReuseAddress = "{\"acceptedVersions\": [\"1.2\"]}";
+    StompClientOptions options1  = new StompClientOptions(new JsonObject(jsonWithValidReuseAddress));
+    assertEquals( 1,options1.getAcceptedVersions().size());
+    assertTrue(options1.getAcceptedVersions().contains("1.2"));
+  }
+
+}


### PR DESCRIPTION
This PR includes:

1. Fix the issue #43 that only half of available ports can be bond in StompClient when both setLocalAddress and setReuseAddress as true.
   Fixed by setting setReuseAddress as false value in the StompClientOptions. 

2. Fix a potential issue in StompClientOptions(JsonObject json), that when the json does not contain 'acceptedVersions' value, the acceptedVersions value will be null. Set it with default value instead.

3. Add StompClientOptionsTest.