### PR TITLE
Fix #76 Do not add a receipt handler to PING Frames, as this will cause a memory leak.

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/impl/StompClientConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/StompClientConnectionImpl.java
@@ -55,7 +55,7 @@ public class StompClientConnectionImpl implements StompClientConnection, Handler
   private volatile long pinger = -1L;
   private volatile long ponger = -1L;
 
-  private Handler<StompClientConnection> pingHandler = connection -> connection.send(Frames.ping());
+  private Handler<StompClientConnection> pingHandler = connection -> connection.send(Frames.ping(), null);
   private Handler<StompClientConnection> closeHandler;
   private Handler<StompClientConnection> droppedHandler = v -> {
     // Do nothing by default.


### PR DESCRIPTION
#76 PING Frames would normally include a receipt handler, which never get resolved, so you will end up with an ever-increasing list of pending receipts.

Passing `null` as the receipt handler should prevent the creation of a pending receipt.