### PR TITLE
Add configurable WebSocket frame type for STOMP messages

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -409,18 +409,25 @@ Don't forget to declare the supported sub-protocols. Without this, the connectio
 Then follow the instructions from  http://jmesnil.net/stomp-websocket/doc/[the StompJS documentation] to connect to
 the server. Here is a simple example:
 
-[source, javascript]
-----
-var url = "ws://localhost:8080/stomp";
-var client = Stomp.client(url);
-var callback = function(frame) {
-   console.log(frame);
-};
+=== Configuring WebSocket Frame Type
 
-client.connect({}, function() {
- var subscription = client.subscribe("foo", callback);
-});
+When using the WebSocket bridge, you can configure whether STOMP frames are sent as WebSocket TEXT or BINARY frames.
+This is important for compatibility with different JavaScript STOMP clients:
+
+[source,$lang]
 ----
+{@link examples.StompServerExamples#exampleWebSocketTextFrames(io.vertx.core.Vertx)}
+----
+
+{@link io.vertx.ext.stomp.WebSocketFrameType} enum provides two options:
+
+* `TEXT` - Sends STOMP frames as WebSocket text frames.
+This is recommended for JavaScript clients (e.g. StompJS) as STOMP is a text-based protocol.
+This is the most compatible option for web browsers.
+* `BINARY` - Sends STOMP frames as WebSocket binary frames.
+This was the default behavior in earlier versions and is maintained for backward compatibility.
+
+WARNING: When using `TEXT` frames, STOMP message bodies containing binary data must be UTF-8 safe or should be Base64 encoded at the application level.
 
 == Registering received and writing frame handlers
 

--- a/src/main/generated/io/vertx/ext/stomp/StompServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/stomp/StompServerOptionsConverter.java
@@ -87,6 +87,11 @@ public class StompServerOptionsConverter {
             obj.setTrailingLine((Boolean)member.getValue());
           }
           break;
+        case "webSocketFrameType":
+          if (member.getValue() instanceof String) {
+            obj.setWebSocketFrameType(io.vertx.ext.stomp.WebSocketFrameType.valueOf((String)member.getValue()));
+          }
+          break;
       }
     }
   }
@@ -118,5 +123,8 @@ public class StompServerOptionsConverter {
       json.put("websocketPath", obj.getWebsocketPath());
     }
     json.put("trailingLine", obj.isTrailingLine());
+    if (obj.getWebSocketFrameType() != null) {
+      json.put("webSocketFrameType", obj.getWebSocketFrameType().name());
+    }
   }
 }

--- a/src/main/java/examples/StompServerExamples.java
+++ b/src/main/java/examples/StompServerExamples.java
@@ -1,17 +1,17 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
- *  ------------------------------------------------------
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
+ * Copyright (c) 2011-2026 The original author or authors
  *
- *       The Eclipse Public License is available at
- *       http://www.eclipse.org/legal/epl-v10.html
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
  *
- *       The Apache License v2.0 is available at
- *       http://www.opensource.org/licenses/apache2.0.php
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
  *
- *  You may elect to redistribute this code under either of these licenses.
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package examples;
@@ -205,6 +205,22 @@ public class StompServerExamples {
         .webSocketHandshakeHandler(server.webSocketHandshakeHandler())
         .webSocketHandler(server.webSocketHandler())
         .listen(8080);
+  }
+
+  public void exampleWebSocketTextFrames(Vertx vertx) {
+    StompServer server = StompServer.create(vertx, new StompServerOptions()
+        .setPort(-1) // Disable the TCP port, optional
+        .setWebsocketBridge(true) // Enable the web socket support
+        .setWebsocketPath("/stomp") // Configure the web socket path, /stomp by default
+        .setWebSocketFrameType(WebSocketFrameType.TEXT)) // Use TEXT frames for JavaScript clients
+      .handler(StompServerHandler.create(vertx));
+
+    Future<HttpServer> http = vertx.createHttpServer(
+        new HttpServerOptions().setWebSocketSubProtocols(Arrays.asList("v10.stomp", "v11.stomp", "v12.stomp"))
+      )
+      .webSocketHandshakeHandler(server.webSocketHandshakeHandler())
+      .webSocketHandler(server.webSocketHandler())
+      .listen(8080);
   }
 
   public void example17(Vertx vertx) {

--- a/src/main/java/io/vertx/ext/stomp/StompServerOptions.java
+++ b/src/main/java/io/vertx/ext/stomp/StompServerOptions.java
@@ -1,17 +1,17 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
- *  ------------------------------------------------------
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
+ * Copyright (c) 2011-2026 The original author or authors
  *
- *       The Eclipse Public License is available at
- *       http://www.eclipse.org/legal/epl-v10.html
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
  *
- *       The Apache License v2.0 is available at
- *       http://www.opensource.org/licenses/apache2.0.php
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
  *
- *  You may elect to redistribute this code under either of these licenses.
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package io.vertx.ext.stomp;
@@ -70,6 +70,8 @@ public class StompServerOptions extends NetServerOptions implements StompOptions
   private boolean disableTCPServer;
   private boolean trailingLine = DEFAULT_TRAILING_LINE;
 
+  private WebSocketFrameType webSocketFrameType = WebSocketFrameType.BINARY;
+
   /**
    * Default constructor.
    */
@@ -104,6 +106,7 @@ public class StompServerOptions extends NetServerOptions implements StompOptions
 
     this.disableTCPServer = other.disableTCPServer;
     this.trailingLine = other.trailingLine;
+    this.webSocketFrameType = other.webSocketFrameType;
   }
 
   /**
@@ -471,6 +474,41 @@ public class StompServerOptions extends NetServerOptions implements StompOptions
    */
   public StompServerOptions setTrailingLine(boolean trailingLine) {
     this.trailingLine = trailingLine;
+    return this;
+  }
+
+  /**
+   * Gets the WebSocket frame type to use when sending STOMP messages over WebSocket.
+   * <p>
+   * This determines whether STOMP frames are sent as text or binary WebSocket frames.
+   * The default is {@link WebSocketFrameType#BINARY} for backward compatibility.
+   * <p>
+   * Use {@link WebSocketFrameType#TEXT} for compatibility with JavaScript STOMP clients
+   * (e.g. StompJS) as STOMP is a text-based protocol.
+   *
+   * @return the WebSocket frame type, {@link WebSocketFrameType#BINARY} by default
+   */
+  public WebSocketFrameType getWebSocketFrameType() {
+    return webSocketFrameType;
+  }
+
+  /**
+   * Sets the WebSocket frame type to use when sending STOMP messages over WebSocket.
+   * <p>
+   * This determines whether STOMP frames are sent as text or binary WebSocket frames.
+   * <ul>
+   *   <li>{@link WebSocketFrameType#TEXT} - Recommended for JavaScript clients and aligns with
+   *       STOMP being a text-based protocol. Note that STOMP message bodies containing binary
+   *       data must be UTF-8 safe or Base64 encoded at the application level.</li>
+   *   <li>{@link WebSocketFrameType#BINARY} - Legacy behavior, handles any content but may not
+   *       be compatible with some JavaScript STOMP clients.</li>
+   * </ul>
+   *
+   * @param webSocketFrameType the frame type to use
+   * @return the current {@link StompServerOptions}
+   */
+  public StompServerOptions setWebSocketFrameType(WebSocketFrameType webSocketFrameType) {
+    this.webSocketFrameType = webSocketFrameType;
     return this;
   }
 }

--- a/src/main/java/io/vertx/ext/stomp/WebSocketFrameType.java
+++ b/src/main/java/io/vertx/ext/stomp/WebSocketFrameType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2026 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.stomp;
+
+/**
+ * Defines the type of WebSocket frames to use when sending STOMP messages over WebSocket.
+ * <p>
+ * This configuration allows choosing between text and binary WebSocket frames for STOMP message transmission.
+ * The choice affects compatibility with different STOMP clients:
+ * <ul>
+ *   <li>{@link #TEXT} - Uses text WebSocket frames. Compatible with JavaScript STOMP clients (e.g. StompJS).
+ *       This is the recommended default for most use cases as STOMP is a text-based protocol.</li>
+ *   <li>{@link #BINARY} - Uses binary WebSocket frames. This was the legacy behavior and may be needed for
+ *       backward compatibility with existing applications that expect binary frames.</li>
+ * </ul>
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public enum WebSocketFrameType {
+  /**
+   * Use text WebSocket frames for STOMP messages.
+   * <p>
+   * This is the recommended option for maximum compatibility with JavaScript STOMP clients
+   * and aligns with STOMP being a text-oriented protocol.
+   * <p>
+   * Note: When using text frames, STOMP message bodies containing binary data must be UTF-8 safe
+   * or should be Base64 encoded at the application level.
+   */
+  TEXT,
+
+  /**
+   * Use binary WebSocket frames for STOMP messages.
+   * <p>
+   * This was the legacy behavior in earlier versions. It handles any content (text or binary)
+   * but may not be compatible with some JavaScript STOMP clients that expect text frames.
+   * <p>
+   * Use this option for backward compatibility with existing applications.
+   */
+  BINARY
+}

--- a/src/main/java/io/vertx/ext/stomp/impl/StompServerWebSocketConnectionImpl.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/StompServerWebSocketConnectionImpl.java
@@ -1,28 +1,27 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ * Copyright (c) 2011-2026 The original author or authors
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
  *
- *       The Eclipse Public License is available at
- *       http://www.eclipse.org/legal/epl-v10.html
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
  *
- *       The Apache License v2.0 is available at
- *       http://www.opensource.org/licenses/apache2.0.php
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
  *
- *  You may elect to redistribute this code under either of these licenses.
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package io.vertx.ext.stomp.impl;
-
-import javax.net.ssl.SSLSession;
 
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.ext.stomp.*;
 
+import javax.net.ssl.SSLSession;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -36,11 +35,13 @@ public class StompServerWebSocketConnectionImpl extends StompServerTCPConnection
   private final ServerWebSocket socket;
 
   private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final WebSocketFrameType webSocketFrameType;
 
   public StompServerWebSocketConnectionImpl(ServerWebSocket socket, StompServer server, Handler<ServerFrame> writtenFrameHandler) {
     super(server, writtenFrameHandler);
     Objects.requireNonNull(socket);
     this.socket = socket;
+    webSocketFrameType = server.options().getWebSocketFrameType();
   }
 
   @Override
@@ -50,7 +51,11 @@ public class StompServerWebSocketConnectionImpl extends StompServerTCPConnection
 
   @Override
   public StompServerConnection write(Buffer buffer) {
-    socket.writeBinaryMessage(buffer);
+    if (webSocketFrameType == WebSocketFrameType.TEXT) {
+      socket.writeTextMessage(buffer.toString("UTF-8"));
+    } else {
+      socket.writeBinaryMessage(buffer);
+    }
     return this;
   }
 

--- a/src/test/java/io/vertx/stomp/tests/impl/WebSocketTextFrameTest.java
+++ b/src/test/java/io/vertx/stomp/tests/impl/WebSocketTextFrameTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2011-2026 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.stomp.tests.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.ext.stomp.*;
+import io.vertx.ext.stomp.utils.Headers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test WebSocket TEXT frame mode for STOMP messages.
+ * Verifies that when configured with WebSocketFrameType.TEXT, the server sends
+ * STOMP frames as WebSocket text frames instead of binary frames.
+ */
+public class WebSocketTextFrameTest {
+
+  private Vertx vertx;
+  private StompServer server;
+  private HttpServer http;
+  private WebSocketConnectOptions options;
+  private List<StompClient> clients = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+
+    // Configure server to use TEXT WebSocket frames
+    server = StompServer.create(vertx, new StompServerOptions()
+        .setWebsocketBridge(true)
+        .setWebSocketFrameType(io.vertx.ext.stomp.WebSocketFrameType.TEXT))  // Use TEXT frames
+      .handler(StompServerHandler.create(vertx));
+
+    HttpServerOptions httpOptions = new HttpServerOptions()
+      .setMaxWebSocketFrameSize(1024)
+      .setMaxWebSocketMessageSize(2048)
+      .setPort(8080);
+
+    http = vertx.createHttpServer(httpOptions)
+      .webSocketHandshakeHandler(server.webSocketHandshakeHandler())
+      .webSocketHandler(server.webSocketHandler());
+
+    options = new WebSocketConnectOptions()
+      .setPort(8080)
+      .setURI("/stomp")
+      .addHeader("Sec-WebSocket-Protocol", "v10.stomp, v11.stomp, v12.stomp");
+  }
+
+  private void startServers() {
+    if (server.options().getPort() != -1) {
+      AsyncLock<StompServer> stompLock = new AsyncLock<>();
+      server.listen().onComplete(stompLock.handler());
+      stompLock.waitForSuccess();
+    }
+    AsyncLock<HttpServer> httpLock = new AsyncLock<>();
+    http.listen().onComplete(httpLock.handler());
+    httpLock.waitForSuccess();
+  }
+
+  @After
+  public void tearDown() {
+    clients.forEach(StompClient::close);
+    clients.clear();
+
+    AsyncLock<Void> lock = new AsyncLock<>();
+    server.close().onComplete(lock.handler());
+    lock.waitForSuccess();
+
+    lock = new AsyncLock<>();
+    http.close().onComplete(lock.handler());
+    lock.waitForSuccess();
+
+    lock = new AsyncLock<>();
+    vertx.close().onComplete(lock.handler());
+    lock.waitForSuccess();
+  }
+
+  @Test
+  public void testTextFrameConnection() {
+    startServers();
+
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    AtomicReference<Buffer> frame = new AtomicReference<>();
+    AtomicReference<WebSocket> socket = new AtomicReference<>();
+    AtomicBoolean receivedBinaryFrame = new AtomicBoolean(false);
+
+    WebSocketClient client = vertx.createWebSocketClient();
+    client.connect(options).onComplete(ar -> {
+      if (ar.succeeded()) {
+        WebSocket ws = ar.result();
+        socket.set(ws);
+        ws.exceptionHandler(error::set)
+          .textMessageHandler(text -> {
+            // Should receive STOMP frames as text
+            frame.set(Buffer.buffer(text));
+          })
+          .binaryMessageHandler(buffer -> {
+            // Should NOT receive binary frames in TEXT mode
+            receivedBinaryFrame.set(true);
+          })
+          .write(new Frame(Command.CONNECT, Headers.create("accept-version", "1.2,1.1,1.0",
+            "heart-beat", "10000,10000"), null).toBuffer());
+      }
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> error.get() == null && frame.get() != null);
+    assertThat(receivedBinaryFrame.get()).isFalse();
+    assertThat(frame.get().toString()).startsWith("CONNECTED")
+      .contains("server:vertx-stomp", "heart-beat:", "session:", "version:1.2");
+    socket.get().close();
+  }
+
+  @Test
+  public void testTextFrameMessageExchange() {
+    startServers();
+
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    AtomicReference<Buffer> messageFrame = new AtomicReference<>();
+    AtomicReference<WebSocket> socket = new AtomicReference<>();
+    AtomicBoolean receivedBinaryFrame = new AtomicBoolean(false);
+
+    AtomicReference<StompClientConnection> client = new AtomicReference<>();
+
+    StompClient c = StompClient.create(vertx);
+    c.connect(61613, "localhost").onComplete(connection -> {
+      client.set(connection.result());
+    });
+    clients.add(c);
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> client.get() != null);
+
+    WebSocketClient wsClient = vertx.createWebSocketClient();
+    wsClient.connect(options).onComplete(ar -> {
+      if (ar.succeeded()) {
+        WebSocket ws = ar.result();
+        socket.set(ws);
+        ws.exceptionHandler(error::set)
+          .textMessageHandler(text -> {
+            Buffer buffer = Buffer.buffer(text);
+            if (buffer.toString().startsWith("CONNECTED")) {
+              ws.write(
+                new Frame(Command.SUBSCRIBE, Headers.create("id", "sub-0", "destination", "foo"), null)
+                  .toBuffer());
+              return;
+            }
+            if (messageFrame.get() == null) {
+              messageFrame.set(buffer);
+            }
+          })
+          .binaryMessageHandler(buffer -> {
+            receivedBinaryFrame.set(true);
+          })
+          .write(new Frame(Command.CONNECT, Headers.create("accept-version", "1.2,1.1,1.0",
+            "heart-beat", "10000,10000"), null).toBuffer());
+      }
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> server.stompHandler().getDestination("foo") != null);
+    client.get().send("foo", Headers.create("header", "value"), Buffer.buffer("hello"));
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> error.get() == null && messageFrame.get() != null);
+    assertThat(receivedBinaryFrame.get()).isFalse();
+    assertThat(messageFrame.get().toString()).startsWith("MESSAGE")
+      .contains("destination:foo", "content-length:5", "header:value", "subscription:sub-0", "\nhello");
+    socket.get().close();
+  }
+
+  @Test
+  public void testTextFrameWithUTF8Content() {
+    startServers();
+
+    AtomicReference<Throwable> error = new AtomicReference<>();
+    AtomicReference<Frame> frame = new AtomicReference<>();
+    AtomicReference<WebSocket> socket = new AtomicReference<>();
+    AtomicBoolean receivedBinaryFrame = new AtomicBoolean(false);
+
+    String utf8Message = "Hello 世界 🌍";  // UTF-8 content with Chinese and emoji
+
+    AtomicReference<StompClientConnection> client = new AtomicReference<>();
+
+    StompClient c = StompClient.create(vertx);
+    c.connect(61613, "localhost").onComplete(connection -> {
+      connection.result().subscribe("utf8test", frame::set).onComplete(r -> {
+        client.set(connection.result());
+      });
+    });
+    clients.add(c);
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> client.get() != null);
+    await().atMost(10, TimeUnit.SECONDS).until(() -> server.stompHandler().getDestination("utf8test") != null);
+
+    WebSocketClient wsClient = vertx.createWebSocketClient();
+    wsClient.connect(options).onComplete(ar -> {
+      if (ar.succeeded()) {
+        WebSocket ws = ar.result();
+        socket.set(ws);
+        ws.exceptionHandler(error::set)
+          .textMessageHandler(text -> {
+            if (text.startsWith("CONNECTED")) {
+              ws.write(
+                new Frame(Command.SEND, Headers.create("header", "value", "destination", "utf8test"),
+                  Buffer.buffer(utf8Message)).toBuffer());
+            }
+          })
+          .binaryMessageHandler(buffer -> {
+            receivedBinaryFrame.set(true);
+          })
+          .write(new Frame(Command.CONNECT, Headers.create("accept-version", "1.2,1.1,1.0",
+            "heart-beat", "10000,10000"), null).toBuffer());
+      }
+    });
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> error.get() == null && frame.get() != null);
+    assertThat(receivedBinaryFrame.get()).isFalse();
+    assertThat(frame.get().toString()).startsWith("MESSAGE")
+      .contains("destination:utf8test", "header:value", "\n" + utf8Message);
+    socket.get().close();
+  }
+}


### PR DESCRIPTION
See #85

Implements configurable WebSocket frame types (TEXT/BINARY) to fix compatibility issues with JavaScript STOMP clients (e.g. StompJS).

Changes:
- Add WebSocketFrameType enum with TEXT and BINARY options
- Add webSocketFrameType configuration to StompServerOptions
- Update StompServerWebSocketConnectionImpl to use configured frame type
- Default remains BINARY for backward compatibility

Some portions of this content were created with the assistance of IBM Bob.