### PR TITLE
Fix unsafe removal during stream iteration

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/impl/Queue.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/Queue.java
@@ -121,18 +121,15 @@ public class Queue implements Destination {
    */
   @Override
   public synchronized boolean unsubscribe(StompServerConnection connection, Frame frame) {
-    boolean r = false;
-    for (Subscription subscription : subscriptions) {
-      if (subscription.connection.equals(connection) && subscription.id.equals(frame.getId())) {
-        r = subscriptions.remove(subscription);
-        // Subscription id are unique for a connection.
-        break;
-      }
-    }
+    boolean removed = subscriptions.removeIf(
+      // Subscription id are unique for a connection.
+      subscription -> subscription.connection.equals(connection) && subscription.id.equals(frame.getId())
+    );
+
     if (subscriptions.isEmpty()) {
       vertx.sharedData().getLocalMap("stomp.destinations").remove(this);
     }
-    return r;
+    return removed;
   }
 
   /**
@@ -143,10 +140,7 @@ public class Queue implements Destination {
    */
   @Override
   public synchronized Destination unsubscribeConnection(StompServerConnection connection) {
-    new ArrayList<>(subscriptions)
-        .stream()
-        .filter(subscription -> subscription.connection.equals(connection))
-        .forEach(subscriptions::remove);
+    subscriptions.removeIf(subscription -> subscription.connection.equals(connection));
 
     if (subscriptions.isEmpty()) {
       vertx.sharedData().getLocalMap("stomp.destinations").remove(this);

--- a/src/main/java/io/vertx/ext/stomp/impl/Transactions.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/Transactions.java
@@ -89,10 +89,7 @@ public class Transactions {
    * @param connection the connection
    */
   public synchronized void unregisterTransactionsFromConnection(StompServerConnection connection) {
-    transactions.stream()
-        .filter(transaction -> transaction.connection().equals(connection))
-        .sorted() // Avoid using baking up collection.
-        .forEach(transactions::remove);
+    transactions.removeIf(transaction -> transaction.connection().equals(connection));
   }
 
   /**


### PR DESCRIPTION
Motivation:

see #103 

Avoid concurrent modification by replacing unsafe stream removal with removeIf
