### PR TITLE
Fix unsubscribe cleanup logic

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/impl/DefaultStompHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/DefaultStompHandler.java
@@ -127,7 +127,7 @@ public class DefaultStompHandler implements StompServerHandler {
   @Override
   public synchronized void onClose(StompServerConnection connection) {
     // Default behavior.
-    getDestinations().stream().forEach((d) -> d.unsubscribeConnection(connection));
+    getDestinations().forEach((d) -> d.unsubscribeConnection(connection));
     Transactions.instance().unregisterTransactionsFromConnection(connection);
 
     // Remove user, if exists

--- a/src/main/java/io/vertx/ext/stomp/impl/EventBusBridge.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/EventBusBridge.java
@@ -105,29 +105,25 @@ public class EventBusBridge extends Topic {
    */
   @Override
   public synchronized boolean unsubscribe(StompServerConnection connection, Frame frame) {
-    Optional<Subscription> target = subscriptions.stream()
-      .filter(s -> s.connection.equals(connection) && s.id.equals(frame.getId()))
-      .findFirst();
+    Iterator<Subscription> iter = subscriptions.iterator();
 
-    if (target.isEmpty()) {
-      return false;
-    }
+    while (iter.hasNext()) {
+      Subscription subscription = iter.next();
+      if (subscription.connection.equals(connection) && subscription.id.equals(frame.getId())) {
+        iter.remove();
 
-    Subscription subscription = target.get();
-    subscriptions.remove(subscription);
+        if (subscriptions.stream().noneMatch(s -> s.destination.equals(subscription.destination))) {
+          MessageConsumer<?> consumer = registry.remove(subscription.destination);
+          if (consumer != null) {
+            consumer.unregister();
+          }
+        }
 
-    boolean hasSameDestination = subscriptions.stream()
-      .anyMatch(s -> s.destination.equals(subscription.destination));
-
-    // Unregister the consumer when there are no subscriptions left for this destination.
-    if (!hasSameDestination) {
-      MessageConsumer<?> consumer = registry.remove(subscription.destination);
-      if (consumer != null) {
-        consumer.unregister();
+        return true;
       }
     }
 
-    return true;
+    return false;
   }
 
   /**

--- a/src/main/java/io/vertx/ext/stomp/impl/EventBusBridge.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/EventBusBridge.java
@@ -29,6 +29,7 @@ import io.vertx.ext.stomp.utils.Headers;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -104,23 +105,29 @@ public class EventBusBridge extends Topic {
    */
   @Override
   public synchronized boolean unsubscribe(StompServerConnection connection, Frame frame) {
-    for (Subscription subscription : new ArrayList<>(subscriptions)) {
-      if (subscription.connection.equals(connection)
-          && subscription.id.equals(frame.getId())) {
+    Optional<Subscription> target = subscriptions.stream()
+      .filter(s -> s.connection.equals(connection) && s.id.equals(frame.getId()))
+      .findFirst();
 
-        boolean r = subscriptions.remove(subscription);
-        Optional<Subscription> any = subscriptions.stream().filter(s -> s.destination.equals(subscription.destination)).findAny();
-        // We unregister the event bus consumer if there are no subscription on this address anymore.
-        if (!any.isPresent()) {
-          MessageConsumer<?> consumer = registry.remove(subscription.destination);
-          if (consumer != null) {
-            consumer.unregister();
-          }
-        }
-        return r;
+    if (target.isEmpty()) {
+      return false;
+    }
+
+    Subscription subscription = target.get();
+    subscriptions.remove(subscription);
+
+    boolean hasSameDestination = subscriptions.stream()
+      .anyMatch(s -> s.destination.equals(subscription.destination));
+
+    // Unregister the consumer when there are no subscriptions left for this destination.
+    if (!hasSameDestination) {
+      MessageConsumer<?> consumer = registry.remove(subscription.destination);
+      if (consumer != null) {
+        consumer.unregister();
       }
     }
-    return false;
+
+    return true;
   }
 
   /**
@@ -131,21 +138,22 @@ public class EventBusBridge extends Topic {
    */
   @Override
   public synchronized Destination unsubscribeConnection(StompServerConnection connection) {
-    new ArrayList<>(subscriptions)
-        .stream()
-        .filter(subscription -> subscription.connection.equals(connection))
-        .forEach(s -> {
-          subscriptions.remove(s);
-          Optional<Subscription> any = subscriptions.stream().filter(s2 -> s2.destination.equals(s.destination))
-              .findAny();
-          // We unregister the event bus consumer if there are no subscription on this address anymore.
-          if (!any.isPresent()) {
-            MessageConsumer<?> consumer = registry.remove(s.destination);
-            if (consumer != null) {
-              consumer.unregister();
-            }
-          }
-        });
+    Set<String> removedDestinations = subscriptions.stream()
+      .filter(s -> s.connection.equals(connection))
+      .map(s -> s.destination)
+      .collect(Collectors.toSet());
+
+    subscriptions.removeIf(s -> s.connection.equals(connection));
+
+    removedDestinations.stream()
+      .filter(destination -> subscriptions.stream().noneMatch(s -> s.destination.equals(destination)))
+      .forEach(destination -> {
+        MessageConsumer<?> consumer = registry.remove(destination);
+        if (consumer != null) {
+          consumer.unregister();
+        }
+      });
+
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/stomp/impl/Topic.java
+++ b/src/main/java/io/vertx/ext/stomp/impl/Topic.java
@@ -108,18 +108,15 @@ public class Topic implements Destination {
    */
   @Override
   public synchronized boolean unsubscribe(StompServerConnection connection, Frame frame) {
-    boolean r = false;
-    for (Subscription subscription : subscriptions) {
-      if (subscription.connection.equals(connection) && subscription.id.equals(frame.getId())) {
-        r = subscriptions.remove(subscription);
-        // Subscription id are unique for a connection.
-        break;
-      }
-    }
+    boolean removed = subscriptions.removeIf(
+      // Subscription id are unique for a connection.
+      subscription -> subscription.connection.equals(connection) && subscription.id.equals(frame.getId())
+    );
+
     if (subscriptions.isEmpty()) {
       vertx.sharedData().getLocalMap("stomp.destinations").remove(this);
     }
-    return r;
+    return removed;
   }
 
   /**
@@ -130,10 +127,7 @@ public class Topic implements Destination {
    */
   @Override
   public synchronized Destination unsubscribeConnection(StompServerConnection connection) {
-    new ArrayList<>(subscriptions)
-        .stream()
-        .filter(subscription -> subscription.connection.equals(connection))
-        .forEach(subscriptions::remove);
+    subscriptions.removeIf(subscription -> subscription.connection.equals(connection));
 
     if (subscriptions.isEmpty()) {
       vertx.sharedData().getLocalMap("stomp.destinations").remove(this);


### PR DESCRIPTION
Motivation:

#103 

Fixed additional unsubscribe-related logic that followed a similar pattern to the issue being addressed.

While reviewing the affected area, similar logic was found in related subscription cleanup paths, so it was updated to handle subscription removal and consumer cleanup consistently.
